### PR TITLE
Load tools that have been added by thread states

### DIFF
--- a/server/app.mjs
+++ b/server/app.mjs
@@ -126,6 +126,14 @@ const mount = async (location, tool, args, scriptWorkspace, socket, threadID, gp
         state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
         if (state && state.chatState) {
             opts.chatState = state.chatState;
+            // also load the tools defined the states so that when running a thread that has tools added in state, we don't lose them
+            for (let block of script) {
+                if (block.type === "tool") {
+                    if (!block.tools) block.tools = [];
+                    block.tools = [...new Set([...block.tools || [], ...(state.tools || [])])];
+                    break;
+                }
+            }
             socket.emit("loaded", {messages: state.messages, tools: state.tools || []});
         }
     } catch (e) {


### PR DESCRIPTION
Once tools have been added by thread states, restarting thread will lose them. This changes so that when thread is loaded, the tool is added from state.json.