### PR TITLE
Fix thread bug where thread is not set when created on the fly

### DIFF
--- a/components/script.tsx
+++ b/components/script.tsx
@@ -33,6 +33,7 @@ const Script: React.FC<ScriptProps> = ({ className, messagesHeight = 'h-full', e
         messages,
         setMessages,
         thread,
+        setThread,
         setThreads,
         setSelectedThreadId,
         socket,

--- a/components/script/chatBar/upload/workspace.tsx
+++ b/components/script/chatBar/upload/workspace.tsx
@@ -17,7 +17,7 @@ interface WorkspaceProps {
 
 const Workspace = ({onRestart}: WorkspaceProps) => {
     const [isOpen, setIsOpen] = useState(false);
-    const {workspace, setWorkspace, thread} = useContext(ScriptContext);
+    const {workspace, setWorkspace, selectedThreadId} = useContext(ScriptContext);
     const [workspaceInput, setWorkspaceInput] = useState<string>('');
 
     useEffect(() => {
@@ -29,7 +29,8 @@ const Workspace = ({onRestart}: WorkspaceProps) => {
     const handleConfirm = useCallback(() => {
         setWorkspace(workspaceInput);
         setIsOpen(false);
-        updateThreadWorkspace(thread, workspaceInput);
+        // Here we use selectedThreadId here because it is always set after thread is created. Thread might not be set when it is created on the fly.
+        updateThreadWorkspace(selectedThreadId ?? '', workspaceInput);
         onRestart();
     }, [workspaceInput]);
 

--- a/contexts/script.tsx
+++ b/contexts/script.tsx
@@ -82,7 +82,7 @@ const ScriptContextProvider: React.FC<ScriptContextProps> = ({children, initialS
     const [initialFetch, setInitialFetch] = useState(false);
     const [subTool, setSubTool] = useState(initialSubTool || '');
     const { 
-        socket, connected, running, messages, setMessages, restart, interrupt, generating, error, setRunning, tools, setTools, forceRun, setForceRun
+        socket, connected, running, messages, setMessages, restart, interrupt, generating, error, setRunning, tools, setTools, forceRun, setForceRun, 
     } = useChatSocket(isEmpty);
 
     // need to initialize the workspace from the env variable with serves
@@ -171,6 +171,11 @@ const ScriptContextProvider: React.FC<ScriptContextProps> = ({children, initialS
         // conditions. In particular, the restart may not be processed correctly and can
         // get the user into a state where no run has been sent to the server.
         debounce(async () => {
+            // Here we specifically update Thread with selectedThreadId so that when it restarts it restarts with the specific thread.
+            // We don't set thread directly after creating because it will re-render the page once thread is created on the fly
+            if (selectedThreadId) {
+                setThread(selectedThreadId);	
+            }
             setRunning(false);
             setHasRun(false);
             setInitialFetch(false);
@@ -199,7 +204,7 @@ const ScriptContextProvider: React.FC<ScriptContextProps> = ({children, initialS
             }
             restart();
         }, 200),
-        [script, thread, restart]
+        [script, thread, restart, selectedThreadId]
     );
 
     return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acorn",
-  "version": "v0.9.4",
+  "version": "v0.10.0-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acorn",
-      "version": "v0.9.4",
+      "version": "v0.10.0-rc1",
       "dependencies": {
         "@gptscript-ai/gptscript": "^0.9.5-rc1",
         "@monaco-editor/react": "^4.6.0",


### PR DESCRIPTION
This PR should fix all the bugs where workspace and restart is behaving weird when thread is created on the fly.

The issue is that when thread is created on the first user message, thread is not set. This is causing multiple unexpected behavior where managing workspace and restart relies on thread variable.

https://github.com/gptscript-ai/gptscript/issues/724
https://github.com/gptscript-ai/gptscript/issues/771
https://github.com/gptscript-ai/gptscript/issues/743