### PR TITLE
Fix workspace not being set when thread is first created.

### DIFF
--- a/actions/threads.tsx
+++ b/actions/threads.tsx
@@ -88,7 +88,7 @@ export async function generateThreadName(firstMessage: string): Promise<string> 
     return summary.text();
 }
 
-export async function createThread(script: string, firstMessage?: string, scriptId?: string): Promise<Thread> {
+export async function createThread(script: string, firstMessage?: string, scriptId?: string, workspace?: string): Promise<Thread> {
     const threadsDir = THREADS_DIR();
 
     // will probably want something else for this
@@ -101,7 +101,7 @@ export async function createThread(script: string, firstMessage?: string, script
         description: '',
         created: new Date(),
         updated: new Date(),
-        workspace: WORKSPACE_DIR(),
+        workspace: workspace ?? WORKSPACE_DIR(),
         id,
         scriptId: scriptId || '',
         script,

--- a/components/script.tsx
+++ b/components/script.tsx
@@ -43,6 +43,7 @@ const Script: React.FC<ScriptProps> = ({ className, messagesHeight = 'h-full', e
         restartScript,
         scriptId,
         fetchThreads,
+        workspace,
     } = useContext(ScriptContext);
 
     useEffect(() => {
@@ -78,7 +79,7 @@ const Script: React.FC<ScriptProps> = ({ className, messagesHeight = 'h-full', e
 
         let threadId = "";
         if (hasNoUserMessages() && enableThreads && !thread && setThreads && setSelectedThreadId) {
-            const newThread = await createThread(script, message, scriptId);
+            const newThread = await createThread(script, message, scriptId, workspace);
             threadId = newThread?.meta?.id;
             setThreads(await getThreads());
             setSelectedThreadId(threadId);

--- a/components/script/chatBar/upload/workspace.tsx
+++ b/components/script/chatBar/upload/workspace.tsx
@@ -30,7 +30,9 @@ const Workspace = ({onRestart}: WorkspaceProps) => {
         setWorkspace(workspaceInput);
         setIsOpen(false);
         // Here we use selectedThreadId here because it is always set after thread is created. Thread might not be set when it is created on the fly.
-        updateThreadWorkspace(selectedThreadId ?? '', workspaceInput);
+        if (selectedThreadId) {
+            updateThreadWorkspace(selectedThreadId, workspace);
+        }
         onRestart();
     }, [workspaceInput]);
 


### PR DESCRIPTION
There is an issue where workspace is changed before thread gets created. The changed workspace is not passed into thread when it is getting created. This PR changes so that the workspace that user changed will get persisted into the thread when it gets created.

https://github.com/gptscript-ai/gptscript/issues/743