### PR TITLE
chore: bump node-gptscript to v0.9.5-rc2 and desktop's package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "acorn",
-  "version": "v0.10.0-rc1",
+  "version": "v0.10.0-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acorn",
-      "version": "v0.10.0-rc1",
+      "version": "v0.10.0-rc2",
       "dependencies": {
-        "@gptscript-ai/gptscript": "^0.9.5-rc1",
+        "@gptscript-ai/gptscript": "^0.9.5-rc2",
         "@monaco-editor/react": "^4.6.0",
         "@nextui-org/button": "2.0.32",
         "@nextui-org/code": "2.0.28",
@@ -508,9 +508,9 @@
       }
     },
     "node_modules/@gptscript-ai/gptscript": {
-      "version": "0.9.5-rc1",
-      "resolved": "https://registry.npmjs.org/@gptscript-ai/gptscript/-/gptscript-0.9.5-rc1.tgz",
-      "integrity": "sha512-ECemK0wt9n5TEx+q7zRwNIhNso/Hy3fYXlie1pxENdk164jU6RVefUl6uEI/bVoI1xWEkqA/cjBGqKoRlIOPKw==",
+      "version": "0.9.5-rc2",
+      "resolved": "https://registry.npmjs.org/@gptscript-ai/gptscript/-/gptscript-0.9.5-rc2.tgz",
+      "integrity": "sha512-slDxATgtBI/yraRIWAV1Hln9Li2Nwwfzs6xoff/HRuwK0LwBnOXLD8dtxZ4bOcERgkxVPapQI9oRuhjW5Xy/lw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://acorn.io"
   },
   "private": true,
-  "version": "v0.10.0-rc1",
+  "version": "v0.10.0-rc2",
   "scripts": {
     "build": "next build --no-lint",
     "build:electron": "next build --no-lint && node electron/build.mjs",
@@ -20,7 +20,7 @@
   },
   "main": "electron/main.mjs",
   "dependencies": {
-    "@gptscript-ai/gptscript": "^0.9.5-rc1",
+    "@gptscript-ai/gptscript": "^0.9.5-rc2",
     "@monaco-editor/react": "^4.6.0",
     "@nextui-org/button": "2.0.32",
     "@nextui-org/code": "2.0.28",


### PR DESCRIPTION
Prep for the `v0.10.0-rc2` pre-release by bumping node-gptscript and desktop's package version.
