### PR TITLE
Fix: use ReplaceAll to replace space when contructing slug

### DIFF
--- a/components/scripts/create.tsx
+++ b/components/scripts/create.tsx
@@ -18,7 +18,7 @@ export default function Create() {
 
     const handleSubmit = async () => {
         const defaultName = "New Assistant";
-        const slug = defaultName.toLowerCase().replace(" ", "-") + "-" + Math.random().toString(36).substring(2, 7);
+        const slug = defaultName.toLowerCase().replaceAll(" ", "-") + "-" + Math.random().toString(36).substring(2, 7);
         createScript({
             displayName: defaultName,
             slug,

--- a/contexts/edit.tsx
+++ b/contexts/edit.tsx
@@ -178,7 +178,7 @@ const EditContextProvider: React.FC<EditContextProps> = ({scriptPath, children})
                 // Only update slug when displayName has changed
                 if (existing?.displayName !== root.name) {
                     toUpdate.displayName = root.name;
-                    toUpdate.slug = toUpdate.displayName?.toLowerCase().replace(" ", "-") + "-" + Math.random().toString(36).substring(2, 7);
+                    toUpdate.slug = toUpdate.displayName?.toLowerCase().replaceAll(" ", "-") + "-" + Math.random().toString(36).substring(2, 7);
                 } else {
                     toUpdate.slug = existing?.slug;
                 }


### PR DESCRIPTION
Need to use `replaceAll` to replace slug with space. 