### PR TITLE
fix: create workspace dir before browsersettings.json

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -39,6 +39,7 @@ async function startServer(isPackaged) {
   console.log(`Starting app server with GPTSCRIPT_BIN="${process.env.GPTSCRIPT_BIN}"`);
 
   // Set up the browser tool to run in headless mode.
+  ensureDirExists(process.env.WORKSPACE_DIR)
   writeFileSync(`${process.env.WORKSPACE_DIR}/browsersettings.json`, JSON.stringify({ headless: true }));
 
   try {


### PR DESCRIPTION
If the app is being started for the first time, the workspace directory doesn't exist, so startup will fail with an error. To fix this, ensure the workspace directory is created at startup.

