### PR TITLE
fix: erase script content when switching threads

### DIFF
--- a/components/threads.tsx
+++ b/components/threads.tsx
@@ -12,6 +12,7 @@ interface ThreadsProps {
 const Threads: React.FC<ThreadsProps> = () => {
   const {
     setScript,
+    setScriptContent,
     setThread,
     threads,
     setScriptId,
@@ -22,6 +23,7 @@ const Threads: React.FC<ThreadsProps> = () => {
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   const handleRun = async (script: string, id: string, scriptId: string) => {
+    setScriptContent(null);
     setScript(script);
     setThread(id);
     setScriptId(scriptId);

--- a/contexts/script.tsx
+++ b/contexts/script.tsx
@@ -30,6 +30,7 @@ interface ScriptContextState {
   subTool: string;
   setSubTool: React.Dispatch<React.SetStateAction<string>>;
   setScript: React.Dispatch<React.SetStateAction<string>>;
+  setScriptContent: React.Dispatch<React.SetStateAction<Block[] | null>>;
   tool: Tool;
   setTool: React.Dispatch<React.SetStateAction<Tool>>;
   showForm: boolean;
@@ -269,6 +270,7 @@ const ScriptContextProvider: React.FC<ScriptContextProps> = ({
         setScriptId,
         script,
         setScript,
+        setScriptContent,
         workspace,
         setWorkspace,
         tool,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acorn",
-  "version": "v0.10.0-rc2",
+  "version": "v0.10.0-rc3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acorn",
-      "version": "v0.10.0-rc2",
+      "version": "v0.10.0-rc3",
       "dependencies": {
         "@gptscript-ai/gptscript": "^0.9.5-rc2",
         "@monaco-editor/react": "^4.6.0",


### PR DESCRIPTION
for #161

The issue linked above was happening whenever the user switches from a Claude thread back to a normal gpt-4o. I figured out that this is just one case of a broader bug in the code, where switching threads can cause the previously selected script to execute.

The script context has a `script` and `scriptContent` state, the latter taking priority over the former. The thread code was overwriting `script` but doing nothing to `scriptContent`, which was the source of the issue here.