### PR TITLE
Feat: Add finish button when creating or editing assistant

### DIFF
--- a/components/edit/configure.tsx
+++ b/components/edit/configure.tsx
@@ -15,9 +15,11 @@ import {
   Tooltip,
   Accordion,
   AccordionItem,
+  Button,
 } from '@nextui-org/react';
 import { PiToolboxBold } from 'react-icons/pi';
 import AssistantNotFound from '@/components/assistant-not-found';
+import { useRouter } from 'next/navigation';
 
 interface ConfigureProps {
   collapsed?: boolean;
@@ -25,6 +27,7 @@ interface ConfigureProps {
 }
 
 const Configure: React.FC<ConfigureProps> = ({ collapsed }) => {
+  const router = useRouter();
   const {
     root,
     setRoot,
@@ -177,6 +180,16 @@ const Configure: React.FC<ConfigureProps> = ({ collapsed }) => {
             />
           </AccordionItem>
         </Accordion>
+      </div>
+      <div className="w-full justify-end px-2 flex space-y-4 mb-6">
+        <Button
+          color="primary"
+          onClick={() => {
+            router.push('/build');
+          }}
+        >
+          Finish
+        </Button>
       </div>
     </>
   );


### PR DESCRIPTION
This adds a finish button when creating/editing assistant that takes you back to the assistance page.

https://github.com/gptscript-ai/desktop/issues/117

<img width="1231" alt="image" src="https://github.com/user-attachments/assets/93ee7dcc-7ca4-48e8-9d06-06ebaf32ad63">
