### PR TITLE
feat: write combined server and client logs to the console and a file

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -6,7 +6,7 @@ export default function Error({
   error,
   reset,
 }: {
-  error: Error;
+  error: Error & { digest?: string };
   reset: () => void;
 }) {
   useEffect(() => {

--- a/contexts/script.tsx
+++ b/contexts/script.tsx
@@ -221,7 +221,7 @@ const ScriptContextProvider: React.FC<ScriptContextProps> = ({
   };
 
   const restartScript = useCallback(
-    // This is debonced as allowing the user to spam the restart button can cause race
+    // This is debounced as allowing the user to spam the restart button can cause race
     // conditions. In particular, the restart may not be processed correctly and can
     // get the user into a state where no run has been sent to the server.
     debounce(async () => {

--- a/electron/config.mjs
+++ b/electron/config.mjs
@@ -1,0 +1,82 @@
+import { app } from 'electron';
+import { getPort } from 'get-port-please';
+import { join, dirname, parse } from 'path';
+import log from 'electron-log/main.js';
+import util from 'util';
+import { renameSync } from 'fs';
+
+// App config
+const dev = !app.isPackaged;
+const appName = 'Acorn';
+const appDir = app.getAppPath();
+const logsDir = app.getPath('logs');
+const resourcesDir = dirname(appDir);
+const dataDir = join(app.getPath('userData'), appName);
+const threadsDir = process.env.THREADS_DIR || join(dataDir, 'threads');
+const workspaceDir = process.env.WORKSPACE_DIR || join(dataDir, 'workspace');
+const port =
+  process.env.PORT ||
+  (!dev ? await getPort({ portRange: [30000, 40000] }) : 3000);
+const gptscriptBin =
+  process.env.GPTSCRIPT_BIN ||
+  join(
+    dev ? join(resourcesDir, 'app.asar.unpacked') : '',
+    'node_modules',
+    '@gptscript-ai',
+    'gptscript',
+    'bin',
+    `gptscript${process.platform === 'win32' ? '.exe' : ''}`
+  );
+const gatewayUrl =
+  process.env.GPTSCRIPT_GATEWAY_URL || 'https://gateway-api.gptscript.ai';
+
+// Logging config
+const logFormat = ({ data, level, message }) => [
+  message.date.toISOString(),
+  `[${message.variables.processType === 'main' ? 'server' : 'client'}]`,
+  `[${level.toUpperCase()}]`,
+  util.format(...data),
+];
+
+log.transports.console.format = logFormat;
+
+Object.assign(log.transports.file, {
+  format: logFormat,
+  resolvePathFn: (variables) => {
+    return join(logsDir, `${variables.appName}.log`);
+  },
+  archiveLogFn: (file) => {
+    // Get the current Unix timestamp
+    const info = parse(file.toString());
+    const timestamp = Math.floor(Date.now() / 1000);
+
+    try {
+      renameSync(file, join(info.dir, `${info.name}.${timestamp}.${info.ext}`));
+    } catch (e) {
+      console.warn('failed to rotate log file', e);
+    }
+  },
+});
+
+log.initialize({
+  // Include logs gathered from clients via IPC
+  spyRendererConsole: true,
+  includeFutureSessions: true,
+});
+
+// Forward default console logging to electron-log
+Object.assign(console, log.functions);
+
+export const config = {
+  dev,
+  appName,
+  logsDir,
+  appDir,
+  resourcesDir,
+  dataDir,
+  threadsDir,
+  workspaceDir,
+  port,
+  gptscriptBin,
+  gatewayUrl,
+};

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -1,5 +1,9 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
+// Import electron-log preload injection to enable log forwarding from clients (i.e. the renderer process) to the server
+// (i.e. the main process).
+import 'electron-log/preload.js';
+
 contextBridge.exposeInMainWorld('electronAPI', {
   on: (channel, callback) => {
     ipcRenderer.on(channel, callback);

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "autoprefixer": "10.4.19",
         "clsx": "^2.0.0",
         "dotenv": "^16.4.5",
+        "electron-log": "^5.1.7",
         "eslint-config-next": "14.2.1",
         "fix-path": "^4.0.0",
         "framer-motion": "^11.1.1",
@@ -7479,6 +7480,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.1.7.tgz",
+      "integrity": "sha512-/PjrS9zGkrZCDTHt6IgNE3FeciBbi4wd7U76NG9jAoNXF99E9IJdvBkqvaUJ1NjLojYDKs0kTvn9YhKy1/Zi+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-publish": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "autoprefixer": "10.4.19",
     "clsx": "^2.0.0",
     "dotenv": "^16.4.5",
+    "electron-log": "^5.1.7",
     "eslint-config-next": "14.2.1",
     "fix-path": "^4.0.0",
     "framer-motion": "^11.1.1",

--- a/server.mjs
+++ b/server.mjs
@@ -9,9 +9,9 @@ dotenv.config({ path: ['.env', '.env.local'] });
 const dev = process.env.NODE_ENV !== 'production';
 const hostname = 'localhost';
 const port = parseInt(process.env.GPTSCRIPT_PORT ?? '3000');
-const dir = dirname(fileURLToPath(import.meta.url));
+const appDir = dirname(fileURLToPath(import.meta.url));
 const runFile = process.env.UI_RUN_FILE;
-startAppServer({ dev, hostname, port, dir })
+startAppServer({ dev, hostname, port, appDir })
   .then((address) => {
     let landingPage = address;
     if (runFile) {

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -18,7 +18,7 @@ let serverRunning = false;
 let gptscriptInitialized = false;
 let gptscriptInitPromise = null;
 
-export const startAppServer = ({ dev, hostname, port, dir }) => {
+export const startAppServer = ({ dev, hostname, port, appDir }) => {
   const address = `http://${hostname}:${port ?? 3000}`;
 
   return new Promise((resolve, reject) => {
@@ -32,7 +32,7 @@ export const startAppServer = ({ dev, hostname, port, dir }) => {
       hostname: hostname,
       port: port,
       conf: nextConfig,
-      dir: dir,
+      dir: appDir,
       customServer: true,
     });
     const handler = app.getRequestHandler();


### PR DESCRIPTION
Capture the combined log output from both client and server side and write them to the console and a log file (at `~/Library/Logs/acorn/acorn.log` on MacOS).

Log files are rotated at 1 MB.

Notes:
- This is the simpler of two approaches I'd played with, [the other](https://github.com/njhale/desktop/commit/4c022192888999cd241a4d3194c6ab5d85f92c75#diff-964ef2320b4c8d24957141cb9d4fa240c0c58871774b924aa2090eef2879dccd) had more control over the log formats -- e.g. color, json output, etc -- and log rotation, but was more complex and had some issues capturing everything.
- For logging to be an effective means to debug, we're going to want to instrument more of the business logic -- e.g. the socket server -- with debug logs. Be on the look out for a PR in the near future adding this.
- Long term, we may want to look at setting up OTEL logging to a file for improved tracing
- I'm going to follow this up with an error page that prints a snippet of the logs around the digest for uncaught errors and provides a "download logs" button that downloads a zip of the logs.
- We're likely also going to want to zip up the gptscript logs/config/cache with this to get a complete picture of what's going on when a user encounters an error, but I'll hold off on that for now.
