### PR TITLE
Feat: Use thread unique workspace, add knowledge ingest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ next-env.d.ts
 # app output directories
 /gptscripts
 /threads
+
+bin/

--- a/actions/knowledge/knowledge.ts
+++ b/actions/knowledge/knowledge.ts
@@ -14,20 +14,7 @@ export async function ingest(
     throw new Error('Dataset ID is required');
   }
   const dir = path.join(workspace, 'knowledge');
-  let knowledgeBinaryPath = '';
-  if (process.env.KNOWLEDGE_BIN) {
-    knowledgeBinaryPath = process.env.KNOWLEDGE_BIN;
-  } else {
-    if (process.env.NODE_ENV === 'production') {
-      knowledgeBinaryPath = path.join(
-        process.resourcesPath,
-        'bin',
-        'knowledge' + (process.platform === 'win32' ? '.exe' : '')
-      );
-    } else {
-      knowledgeBinaryPath = path.join(process.cwd(), 'bin', 'knowledge');
-    }
-  }
+  const knowledgeBinaryPath = process.env.KNOWLEDGE_BIN;
   await execPromise(
     `${knowledgeBinaryPath} ingest --dataset ${datasetID} ${dir.replace(/ /g, '\\ ')}`,
     { env: { ...process.env, GPTSCRIPT_GATEWAY_API_KEY: token } }

--- a/actions/knowledge/knowledge.ts
+++ b/actions/knowledge/knowledge.ts
@@ -1,0 +1,36 @@
+'use server';
+import path from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execPromise = promisify(exec);
+
+export async function ingest(
+  workspace: string,
+  token: string | undefined,
+  datasetID?: string | null
+): Promise<void> {
+  if (!datasetID) {
+    throw new Error('Dataset ID is required');
+  }
+  const dir = path.join(workspace, 'knowledge');
+  let knowledgeBinaryPath = '';
+  if (process.env.KNOWLEDGE_BIN) {
+    knowledgeBinaryPath = process.env.KNOWLEDGE_BIN;
+  } else {
+    if (process.env.NODE_ENV === 'production') {
+      knowledgeBinaryPath = path.join(
+        process.resourcesPath,
+        'bin',
+        'knowledge' + (process.platform === 'win32' ? '.exe' : '')
+      );
+    } else {
+      knowledgeBinaryPath = path.join(process.cwd(), 'bin', 'knowledge');
+    }
+  }
+  await execPromise(
+    `${knowledgeBinaryPath} ingest --dataset ${datasetID} ${dir.replace(/ /g, '\\ ')}`,
+    { env: { ...process.env, GPTSCRIPT_GATEWAY_API_KEY: token } }
+  );
+  return;
+}

--- a/actions/threads.tsx
+++ b/actions/threads.tsx
@@ -31,8 +31,8 @@ export async function getThreads() {
   let threadDirs: void | string[] = [];
   try {
     threadDirs = await fs.readdir(threadsDir);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (e) {
-    console.error('Failed to read threads directory', e);
     return [];
   }
 

--- a/actions/upload.tsx
+++ b/actions/upload.tsx
@@ -5,7 +5,14 @@ import path from 'node:path';
 import { revalidatePath } from 'next/cache';
 import { Dirent } from 'fs';
 
-export async function uploadFile(workspace: string, formData: FormData) {
+export async function uploadFile(
+  workspace: string,
+  formData: FormData,
+  isKnowledge?: boolean
+) {
+  if (isKnowledge) {
+    workspace = path.join(workspace, 'knowledge');
+  }
   const file = formData.get('file') as File;
   await fs.mkdir(workspace, { recursive: true });
 

--- a/app/edit/page.tsx
+++ b/app/edit/page.tsx
@@ -29,7 +29,7 @@ function EditFile() {
     <ScriptContextProvider
       initialScript={file}
       initialScriptId={scriptId}
-      initialThread=""
+      enableThread={false}
     >
       <EditContextProvider scriptPath={file} initialScriptId={scriptId}>
         <div

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,12 +11,10 @@ function RunFile() {
   const [script, _setScript] = useState<string>(
     useSearchParams().get('file') ?? 'github.com/gptscript-ai/ui-assistant'
   );
-  const [thread, _setThread] = useState<string>(
-    useSearchParams().get('thread') ?? ''
-  );
   const [scriptId, _scriptId] = useState<string>(
     useSearchParams().get('id') ?? ''
   );
+
   const { setCurrent } = useContext(NavContext);
 
   useEffect(() => setCurrent('/'), []);
@@ -24,8 +22,8 @@ function RunFile() {
   return (
     <ScriptContextProvider
       initialScript={script}
-      initialThread={thread}
       initialScriptId={scriptId}
+      enableThread={true}
     >
       <section className="absolute left-0 top-[50px]">
         <div

--- a/components/edit/configure/customTool.tsx
+++ b/components/edit/configure/customTool.tsx
@@ -381,7 +381,7 @@ const CustomTool: React.FC<ConfigureProps> = ({ tool }) => {
               <div className="h-full overflow-y-auto">
                 <ScriptContextProvider
                   initialScript={scriptPath}
-                  initialThread=""
+                  enableThread={false}
                   initialSubTool={customTool.name}
                   initialScriptId={`${scriptId}`}
                 >

--- a/components/script/chatBar.tsx
+++ b/components/script/chatBar.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useContext, useEffect } from 'react';
 import { IoMdSend } from 'react-icons/io';
+import { Spinner } from '@nextui-org/react';
 import { FaBackward } from 'react-icons/fa';
 import { Button, Textarea } from '@nextui-org/react';
 import Commands from '@/components/script/chatBar/commands';
@@ -76,7 +77,10 @@ const ChatBar = ({ disabled = false, onMessageSent }: ChatBarProps) => {
         radius="full"
         className="text-lg"
         color="primary"
-        onPress={() => setCommandsOpen(true)}
+        onPress={() => {
+          if (disabled) return;
+          setCommandsOpen(true);
+        }}
         onBlur={() => setTimeout(() => setCommandsOpen(false), 300)} // super hacky but it does work
       />
       <div className="w-full relative">
@@ -128,15 +132,21 @@ const ChatBar = ({ disabled = false, onMessageSent }: ChatBarProps) => {
           onPress={interrupt}
         />
       ) : (
-        <Button
-          startContent={<IoMdSend />}
-          isDisabled={disabled}
-          isIconOnly
-          radius="full"
-          className="text-lg"
-          color="primary"
-          onPress={handleSend}
-        />
+        <>
+          {disabled ? (
+            <Spinner />
+          ) : (
+            <Button
+              startContent={<IoMdSend />}
+              isIconOnly
+              isDisabled={!inputValue}
+              radius="full"
+              className="text-lg"
+              color="primary"
+              onPress={handleSend}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/components/script/chatBar/commands.tsx
+++ b/components/script/chatBar/commands.tsx
@@ -34,8 +34,7 @@ import { ingest } from '@/actions/knowledge/knowledge';
     to the previous command in the list. This is a bit hacky but it works for now.
 */
 
-const gatewayTool =
-  'github.com/StrongMonkey/knowledge@110c951e81cdbcb8ffdc2294e4d0992dce892875';
+const gatewayTool = 'github.com/gptscript-ai/knowledge@v0.4.10-gateway.1';
 
 const options = [
   {

--- a/components/threads/new.tsx
+++ b/components/threads/new.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState, useContext } from 'react';
 import { ScriptContext } from '@/contexts/script';
 import { GoPlus } from 'react-icons/go';
 import { getScripts, Script } from '@/actions/me/scripts';
+import { setWorkspaceDir } from '@/actions/workspace';
 
 interface NewThreadProps {
   className?: string;
@@ -21,7 +22,7 @@ const NewThread = ({ className }: NewThreadProps) => {
   const [scripts, setScripts] = useState<Script[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [_loading, setLoading] = useState(true);
-  const { setThread, setSelectedThreadId, setScript, setThreads, scriptId } =
+  const { setThread, setSelectedThreadId, setScript, setThreads, setScriptId } =
     useContext(ScriptContext);
 
   const fetchScripts = async () => {
@@ -35,12 +36,14 @@ const NewThread = ({ className }: NewThreadProps) => {
     fetchScripts();
   }, [isOpen]);
 
-  const handleCreateThread = (script: string) => {
-    createThread(script, '', scriptId).then((newThread) => {
+  const handleCreateThread = (script: string, id?: string) => {
+    createThread(script, '', id).then((newThread) => {
+      setScriptId(id);
       setThreads((threads: Thread[]) => [newThread, ...threads]);
       setScript(script);
       setThread(newThread.meta.id);
       setSelectedThreadId(newThread.meta.id);
+      setWorkspaceDir(newThread.meta.workspace);
       setLoading(false);
     });
   };
@@ -71,7 +74,7 @@ const NewThread = ({ className }: NewThreadProps) => {
                 className="py-2 truncate max-w-[200px]"
                 content={script.displayName}
                 onClick={() => {
-                  handleCreateThread(script.publicURL!);
+                  handleCreateThread(script.publicURL!, script.id?.toString());
                   setIsOpen(false);
                 }}
               >

--- a/contexts/script.tsx
+++ b/contexts/script.tsx
@@ -148,40 +148,38 @@ const ScriptContextProvider: React.FC<ScriptContextProps> = ({
   }, [script, scriptId, thread]);
 
   useEffect(() => {
-    if (!enableThread) {
+    if (!enableThread || thread || threadInitialized.current) {
       return;
     }
-    if (!thread && !threadInitialized.current) {
-      threadInitialized.current = true;
-      const createAndSetThread = async () => {
-        try {
-          const threads = await getThreads();
-          if ((initialScript && initialScriptId) || threads.length === 0) {
-            // if both threads and scriptId are set, then always create a new thread
-            const newThread = await createThread(
-              script,
-              scriptDisplayName ?? defaultScriptName,
-              scriptId
-            );
-            const threadId = newThread?.meta?.id;
-            setThread(threadId);
-            setThreads(await getThreads());
-            setSelectedThreadId(threadId);
-            setWorkspace(newThread.meta.workspace);
-          } else if (threads.length > 0) {
-            setThreads(threads);
-            const latestThread = threads[0];
-            setThread(latestThread.meta.id);
-            setSelectedThreadId(latestThread.meta.id);
-            setScriptId(latestThread.meta.scriptId);
-          }
-        } catch (e) {
-          threadInitialized.current = false;
-          console.error(e);
+    threadInitialized.current = true;
+    const createAndSetThread = async () => {
+      try {
+        const threads = await getThreads();
+        if ((initialScript && initialScriptId) || threads.length === 0) {
+          // if both threads and scriptId are set, then always create a new thread
+          const newThread = await createThread(
+            script,
+            scriptDisplayName ?? defaultScriptName,
+            scriptId
+          );
+          const threadId = newThread?.meta?.id;
+          setThread(threadId);
+          setThreads(await getThreads());
+          setSelectedThreadId(threadId);
+          setWorkspace(newThread.meta.workspace);
+        } else if (threads.length > 0) {
+          setThreads(threads);
+          const latestThread = threads[0];
+          setThread(latestThread.meta.id);
+          setSelectedThreadId(latestThread.meta.id);
+          setScriptId(latestThread.meta.scriptId);
         }
-      };
-      createAndSetThread();
-    }
+      } catch (e) {
+        threadInitialized.current = false;
+        console.error(e);
+      }
+    };
+    createAndSetThread();
   }, [thread, threads, enableThread, scriptDisplayName]);
 
   useEffect(() => {

--- a/electron/build.mjs
+++ b/electron/build.mjs
@@ -24,6 +24,7 @@ const options = {
     '!**/{__pycache__,thumbs.db,.flowconfig,.idea,.vs,.nyc_output}',
     '!**/{appveyor.yml,.travis.yml,circle.yml}',
     '!**/{npm-debug.log,yarn.lock,.yarn-integrity,.yarn-metadata.json}',
+    'bin/*',
   ],
   mac: {
     hardenedRuntime: true,
@@ -72,6 +73,13 @@ const options = {
     releaseType: 'release',
     vPrefixedTagName: true,
   },
+  extraResources: [
+    {
+      from: 'bin/',
+      to: 'bin',
+      filter: ['**/*'],
+    },
+  ],
 };
 
 function go() {

--- a/electron/config.mjs
+++ b/electron/config.mjs
@@ -27,6 +27,14 @@ const gptscriptBin =
     'bin',
     `gptscript${process.platform === 'win32' ? '.exe' : ''}`
   );
+const knowledgeBin =
+  process.env.KNOWLEDGE_BIN || process.env.NODE_ENV === 'production'
+    ? join(
+        process.resourcesPath,
+        'bin',
+        'knowledge' + (process.platform === 'win32' ? '.exe' : '')
+      )
+    : join(process.cwd(), 'bin', 'knowledge');
 const gatewayUrl =
   process.env.GPTSCRIPT_GATEWAY_URL || 'https://gateway-api.gptscript.ai';
 
@@ -51,7 +59,10 @@ Object.assign(log.transports.file, {
     const timestamp = Math.floor(Date.now() / 1000);
 
     try {
-      renameSync(filePath, join(info.dir, `${info.name}.${timestamp}${info.ext}`));
+      renameSync(
+        filePath,
+        join(info.dir, `${info.name}.${timestamp}${info.ext}`)
+      );
     } catch (e) {
       console.warn('failed to rotate log file', e);
     }
@@ -79,4 +90,5 @@ export const config = {
   port,
   gptscriptBin,
   gatewayUrl,
+  knowledgeBin,
 };

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -31,6 +31,7 @@ async function startServer() {
   process.env.WORKSPACE_DIR = config.workspaceDir;
   process.env.GPTSCRIPT_GATEWAY_URL = config.gatewayUrl;
   process.env.GPTSCRIPT_OPENAPI_REVAMP = 'true';
+  process.env.KNOWLEDGE_BIN = config.knowledgeBin;
 
   try {
     const url = await startAppServer({

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "acorn",
       "version": "v0.10.0-rc3",
+      "hasInstallScript": true,
       "dependencies": {
         "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#de914911013bf9da02046906b88a5613dce508e1",
         "@monaco-editor/react": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "email": "info@acorn.io",
     "url": "https://acorn.io"
   },
+  "files": [
+    "bin"
+  ],
   "private": true,
   "version": "v0.10.0-rc3",
   "scripts": {
@@ -17,7 +20,8 @@
     "dev:electron": "electron .",
     "lint": "next lint",
     "format": "prettier --write .",
-    "start": "cross-env NODE_ENV='production' node server.mjs"
+    "start": "cross-env NODE_ENV='production' node server.mjs",
+    "postinstall": "node scripts/install-binary.mjs"
   },
   "main": "electron/main.mjs",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
     "email": "info@acorn.io",
     "url": "https://acorn.io"
   },
-  "files": [
-    "bin"
-  ],
   "private": true,
   "version": "v0.10.0-rc3",
   "scripts": {

--- a/scripts/install-binary.mjs
+++ b/scripts/install-binary.mjs
@@ -23,7 +23,7 @@ async function downloadAndExtract(url, saveDirectory) {
         if (err) {
           return reject(err);
         }
-        fs.chmod(newFilePath, 0o755, (err) => {
+        fs.chmod(newFilePath, 0o755, (_err) => {
           if (url.endsWith('.zip')) {
             const zip = new AdmZip(downloadedFilePath);
             zip.extractAllTo(saveDirectory, true);
@@ -107,6 +107,7 @@ const fileExist = (path) => {
   try {
     fs.accessSync(path);
     return true;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (err) {
     return false;
   }
@@ -128,17 +129,14 @@ async function needToInstall() {
   }
 }
 
-(async () => {
-  await needToInstall();
-  if (process.env.KNOWLEDGE_SKIP_INSTALL_BINARY === 'true') {
-    console.info('Skipping binary download');
-    process.exit(0);
-  }
-
-  console.log(`Downloading and extracting knowledge binary from ${url}...`);
-  try {
-    await downloadAndExtract(url, outputDir);
-  } catch (error) {
-    console.error('Error downloading and extracting:', error);
-  }
-})();
+await needToInstall();
+if (process.env.KNOWLEDGE_SKIP_INSTALL_BINARY === 'true') {
+  console.info('Skipping binary download');
+  process.exit(0);
+}
+console.log(`Downloading and extracting knowledge binary from ${url}...`);
+try {
+  await downloadAndExtract(url, outputDir);
+} catch (error) {
+  console.error('Error downloading and extracting:', error);
+}

--- a/scripts/install-binary.mjs
+++ b/scripts/install-binary.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+'use strict';
+
+import { DownloaderHelper } from 'node-downloader-helper';
+import fs from 'fs';
+import path from 'path';
+import AdmZip from 'adm-zip';
+import tar from 'tar';
+import util from 'util';
+import child_process from 'child_process';
+
+const exec = util.promisify(child_process.exec);
+
+async function downloadAndExtract(url, saveDirectory) {
+  const dlh = new DownloaderHelper(url, saveDirectory);
+
+  return new Promise((resolve, reject) => {
+    dlh.on('end', () => {
+      const downloadedFilePath = path.join(dlh.getDownloadPath());
+      const newFilePath = path.join(saveDirectory, knowledgeBinaryName);
+      fs.rename(downloadedFilePath, newFilePath, (err) => {
+        if (err) {
+          return reject(err);
+        }
+        fs.chmod(newFilePath, 0o755, (err) => {
+          if (url.endsWith('.zip')) {
+            const zip = new AdmZip(downloadedFilePath);
+            zip.extractAllTo(saveDirectory, true);
+            fs.unlinkSync(downloadedFilePath);
+          } else if (url.endsWith('.tar.gz')) {
+            tar
+              .x({
+                file: downloadedFilePath,
+                cwd: saveDirectory,
+              })
+              .then(() => {
+                fs.unlinkSync(downloadedFilePath); // Delete the tar.gz file after extraction
+              })
+              .catch((error) => reject(error));
+          }
+          resolve();
+        });
+      });
+    });
+    dlh.on('error', (error) => reject(error));
+    dlh.on('progress.throttled', (downloadEvents) => {
+      const percentageComplete =
+        downloadEvents.progress < 100
+          ? downloadEvents.progress.toFixed(2)
+          : 100;
+      console.info(`downloaded: ${percentageComplete}%`);
+    });
+
+    dlh.start();
+  });
+}
+
+async function versions_match() {
+  try {
+    const command = path.join(outputDir, knowledgeBinaryName) + ' version';
+    const { stdout } = await exec(command);
+    return stdout.toString().includes(gptscript_info.version);
+  } catch (err) {
+    console.error('Error checking gptscript version:', err);
+    return false;
+  }
+}
+
+const platform = process.platform;
+let arch = process.arch;
+if (process.platform === 'darwin') {
+  arch = 'amd64';
+} else if (process.arch === 'x64') {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  arch = 'amd64';
+}
+
+let knowledgeBinaryName = 'knowledge';
+if (process.platform === 'win32') {
+  knowledgeBinaryName = 'knowledge.exe';
+}
+
+const gptscript_info = {
+  name: 'gptscript',
+  url: 'https://github.com/gptscript-ai/knowledge/releases/download/',
+  version: 'v0.4.10-gateway',
+};
+
+const pltfm = {
+  win32: 'windows',
+  linux: 'linux',
+  darwin: 'darwin',
+}[platform];
+
+const suffix = {
+  win32: '.exe',
+  linux: '',
+  darwin: '',
+}[platform];
+
+const url = `${gptscript_info.url}${gptscript_info.version}/knowledge-${pltfm}-${arch}${suffix}`;
+
+const outputDir = path.resolve('bin');
+
+const fileExist = (path) => {
+  try {
+    fs.accessSync(path);
+    return true;
+  } catch (err) {
+    return false;
+  }
+};
+
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir);
+  console.info(`${outputDir} directory was created`);
+}
+
+async function needToInstall() {
+  if (fileExist(path.join(outputDir, knowledgeBinaryName))) {
+    console.log('knowledge is installed...');
+    const versions = await versions_match();
+    if (versions) {
+      console.log('gptscript version is up to date...exiting');
+      process.exit(0);
+    }
+  }
+}
+
+(async () => {
+  await needToInstall();
+  if (process.env.KNOWLEDGE_SKIP_INSTALL_BINARY === 'true') {
+    console.info('Skipping binary download');
+    process.exit(0);
+  }
+
+  console.log(`Downloading and extracting knowledge binary from ${url}...`);
+  try {
+    await downloadAndExtract(url, outputDir);
+  } catch (error) {
+    console.error('Error downloading and extracting:', error);
+  }
+})();

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -140,6 +140,10 @@ const mount = async (
     workspace: scriptWorkspace,
     prompt: true,
     confirm: true,
+    env: [
+      ...Object.entries(process.env).map(([key, value]) => `${key}=${value}`),
+      'GPTSCRIPT_THREAD_ID=' + threadID,
+    ],
   };
 
   if (tool) opts.subTool = tool;


### PR DESCRIPTION
This pr adds the following features/changes/improvements:

1. Add new knowledge ingestion workflow. It ingests file using threadID as datasetID after file is uploaded. It also packages latest knowledge binary releases into the app. It also adds new `GPTSCRIPT_THREAD_ID` to gptscript run so that it can be used by knowledge tool to know which dataset it needs to query from.
2. It changes thread to have its unique workspace. For knowledge files, it will be stored in `knowledge` subdir inside its own workspace.
3. Changed so that when you go to chat, if there is no thread, it will automatically create a thread with tildy. Once you have threads, it will go to the latest thread you interacted with.
4. Make so that loading status is moved to message bar/button instead of whole screen.
5. Chatting with new assistant will by default create a thread.