### PR TITLE
fix: pass correct type in rotation logic

### DIFF
--- a/electron/config.mjs
+++ b/electron/config.mjs
@@ -46,12 +46,12 @@ Object.assign(log.transports.file, {
     return join(logsDir, `${variables.appName}.log`);
   },
   archiveLogFn: (file) => {
-    // Get the current Unix timestamp
-    const info = parse(file.toString());
+    const filePath = file.toString();
+    const info = parse(filePath);
     const timestamp = Math.floor(Date.now() / 1000);
 
     try {
-      renameSync(file, join(info.dir, `${info.name}.${timestamp}.${info.ext}`));
+      renameSync(filePath, join(info.dir, `${info.name}.${timestamp}${info.ext}`));
     } catch (e) {
       console.warn('failed to rotate log file', e);
     }


### PR DESCRIPTION
The log rotation is broken such that when the current log file reaches 1 MB, a ton of
errors are generated by electron-log, which causes the file size to balloon in a bad way.

Fix it by correcting the type passed when renaming the old log file.

