### PR TITLE
fix: remove credential tools from dynamically added tools

### DIFF
--- a/server/app.mjs
+++ b/server/app.mjs
@@ -261,12 +261,16 @@ const mount = async (
     for (tool of Object.values(loaded?.program?.toolSet)) {
       if (tool.credentials) {
         for (let cred of tool.credentials) {
-          credentials.push(tool.toolMapping[cred][0].toolID);
+          for (let mapping of tool.toolMapping[cred]) {
+            credentials.push(mapping.toolID);
+          }
         }
       }
       if (tool['exportCredentials']) {
         for (let cred of tool['exportCredentials']) {
-          credentials.push(tool.toolMapping[cred][0].toolID);
+          for (let mapping of tool.toolMapping[cred]) {
+            credentials.push(mapping.toolID);
+          }
         }
       }
     }

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -257,26 +257,26 @@ const mount = async (
     // We need to filter out credential tools so that we do not give them to the LLM.
     // TODO - also filter out context tools maybe?
     const toolSet = {};
-    const credentials = [];
+    const credentials = new Set();
     for (tool of Object.values(loaded?.program?.toolSet)) {
       if (tool.credentials) {
         for (let cred of tool.credentials) {
           for (let mapping of tool.toolMapping[cred]) {
-            credentials.push(mapping.toolID);
+            credentials.add(mapping.toolID);
           }
         }
       }
       if (tool['exportCredentials']) {
         for (let cred of tool['exportCredentials']) {
           for (let mapping of tool.toolMapping[cred]) {
-            credentials.push(mapping.toolID);
+            credentials.add(mapping.toolID);
           }
         }
       }
     }
 
     for (let [key, value] of Object.entries(loaded?.program?.toolSet)) {
-      if (!credentials.includes(key)) {
+      if (!credentials.has(key)) {
         toolSet[key] = value;
       }
     }

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -262,13 +262,11 @@ const mount = async (
       if (tool.credentials) {
         for (let cred of tool.credentials) {
           credentials.push(tool.toolMapping[cred][0].toolID);
-          console.log('pushed tool ID:', tool.toolMapping[cred][0].toolID);
         }
       }
       if (tool['exportCredentials']) {
         for (let cred of tool['exportCredentials']) {
           credentials.push(tool.toolMapping[cred][0].toolID);
-          console.log('pushed tool ID:', tool.toolMapping[cred][0].toolID);
         }
       }
     }
@@ -276,8 +274,6 @@ const mount = async (
     for (let [key, value] of Object.entries(loaded?.program?.toolSet)) {
       if (!credentials.includes(key)) {
         toolSet[key] = value;
-      } else {
-        console.log('skipping tool:', key);
       }
     }
 


### PR DESCRIPTION
We were accidentally giving the LLM the ability to call credential tools when we took this approach to dynamic tool adding. This PR fixes it by filtering out all of the credential tools before giving them to the LLM.