### PR TITLE
fix: add tool to thread state as a string

### DIFF
--- a/server/app.mjs
+++ b/server/app.mjs
@@ -264,8 +264,8 @@ const mount = async (
     // TODO - also filter out context tools maybe?
     const toolSet = {};
     const credentials = new Set();
-    for (tool of Object.values(loaded?.program?.toolSet)) {
-      if (tool.credentials) {
+    for (const t of Object.values(loaded?.program?.toolSet)) {
+      if (t.credentials) {
         for (let cred of tool.credentials) {
           for (let mapping of tool.toolMapping[cred]) {
             credentials.add(mapping.toolID);


### PR DESCRIPTION
Since the tool parameter is passed here as a string and the former for-loop used tool as a Tool object, this caused the tool that was saved in the thread state to be an object rather than a string. This would cause errors when reloading the thread from the file.