### PR TITLE
fix: stop changing icon during chat

### DIFF
--- a/components/script/chatBar/commands.tsx
+++ b/components/script/chatBar/commands.tsx
@@ -137,6 +137,7 @@ export default function Commands({
             ...prev,
             {
               type: MessageType.Alert,
+              name: prev ? prev[prev.length - 1].name : undefined,
               icon: <GoPaperclip className="mt-1" />,
               message: `Uploading knowledge ${file.name}`,
             },
@@ -149,6 +150,7 @@ export default function Commands({
           {
             type: MessageType.Alert,
             icon: <GoCheckCircleFill className="mt-1" />,
+            name: prev ? prev[prev.length - 1].name : undefined,
             message: `Successfully uploaded knowledge ${plainFiles.map((f) => f.name).join(', ')}`,
           },
         ]);
@@ -163,6 +165,7 @@ export default function Commands({
           ...prev,
           {
             type: MessageType.Alert,
+            name: prev ? prev[prev.length - 1].name : undefined,
             icon: <GoAlert className="mt-1" />,
             message: `Error uploading knowledge ${filesContent.map((f) => f.name).join(', ')}: ${e}`,
           },
@@ -204,6 +207,7 @@ export default function Commands({
             {
               type: MessageType.Alert,
               icon: <GoTools className="mt-1" />,
+              name: prev ? prev[prev.length - 1].name : undefined,
               message: `Added ${tool
                 .split('/')
                 .pop()
@@ -219,6 +223,7 @@ export default function Commands({
             {
               type: MessageType.Alert,
               icon: <GoTools className="mt-1" />,
+              name: prev ? prev[prev.length - 1].name : undefined,
               message: `Removed ${tool
                 .split('/')
                 .pop()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "v0.10.0-rc3",
       "hasInstallScript": true,
       "dependencies": {
-        "@gptscript-ai/gptscript": "^0.9.5-rc4",
+        "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#0ec49d9df04627afe4518f4689dc212c0d03cdd6",
         "@monaco-editor/react": "^4.6.0",
         "@nextui-org/button": "2.0.32",
         "@nextui-org/code": "2.0.28",
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@gptscript-ai/gptscript": {
-      "version": "0.9.5-rc4",
-      "resolved": "https://registry.npmjs.org/@gptscript-ai/gptscript/-/gptscript-0.9.5-rc4.tgz",
-      "integrity": "sha512-lD+t6zkASQ9JD9kzukYD2+ueDBaQm8TxpVZabthYUK8RIi8ftoG5hAb8ZOj7+dqEqN8K5dhdhHdnKdOmCxa5MA==",
+      "version": "v0.9.5-rc4",
+      "resolved": "git+ssh://git@github.com/gptscript-ai/node-gptscript.git#0ec49d9df04627afe4518f4689dc212c0d03cdd6",
+      "integrity": "sha512-PyrtO2pLmnfpLyJtQOEUdcsbjBfb+PXvQaFn8nc0MGZEi6rmDtZ554gBfySVKq8AdBirkvGSKhTtRhQK9eQEaw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "main": "electron/main.mjs",
   "dependencies": {
-    "@gptscript-ai/gptscript": "^0.9.5-rc4",
+    "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#0ec49d9df04627afe4518f4689dc212c0d03cdd6",
     "@monaco-editor/react": "^4.6.0",
     "@nextui-org/button": "2.0.32",
     "@nextui-org/code": "2.0.28",


### PR DESCRIPTION
Before this change, the chat icon would change based on the tool that was being called. For example, if an assistant was using a tool that needed to prompt the user, then the icon would change to the initials for that tool. After this change, the icon will only change when the assistant changes.

A side effect that is also addressed in this change: restoring a thread now has the correct icons for the messages. This will only be true for threads created after this change.