### PR TITLE
Fix: Close tool modal after tool is added

### DIFF
--- a/components/script/chatBar/commands.tsx
+++ b/components/script/chatBar/commands.tsx
@@ -211,6 +211,7 @@ export default function Commands({
                 .replace(/\b\w/g, (c) => c.toUpperCase())}`,
             },
           ]);
+          setToolCatalogOpen(false);
         }}
         removeTool={(tool) => {
           socket?.emit('removeTool', tool);


### PR DESCRIPTION
This fixes an issue where toolModal is not closed after adding a tool through command bar.