### PR TITLE
Fix: small tweak to not show divider after the last section

### DIFF
--- a/components/threads/new.tsx
+++ b/components/threads/new.tsx
@@ -98,7 +98,7 @@ const NewThread = ({ className }: NewThreadProps) => {
             </DropdownItem>
           ))}
         </DropdownSection>
-        <DropdownSection title="Explore" showDivider>
+        <DropdownSection title="Explore">
           <DropdownItem key="My Assistants" href="/build">
             {'My Assistants'}
           </DropdownItem>


### PR DESCRIPTION
<img width="240" alt="image" src="https://github.com/user-attachments/assets/dbd0d2fd-84b4-4ad4-98eb-51b96661a718">
Get rid of divider on the last section.