### PR TITLE
fix: allow recovery when the user stops response

### DIFF
--- a/server/app.mjs
+++ b/server/app.mjs
@@ -369,7 +369,7 @@ const mount = async (
       opts.input = message;
       runningScript = await gptscript.evaluate(script, opts);
     } else {
-      name = runningScript.respondingTool().name || '';
+      name = (runningScript.respondingTool() || {}).name || '';
       runningScript = runningScript.nextChat(message);
     }
 


### PR DESCRIPTION
If the user stopped the response, then the responding tool will not be defined because no tool responded.