### PR TITLE
chore: change text color for no tools/knowledge

### DIFF
--- a/components/scripts/knowledge-dropdown.tsx
+++ b/components/scripts/knowledge-dropdown.tsx
@@ -93,7 +93,7 @@ const ScriptKnowledgeDropdown = () => {
             <DropdownItem
               aria-label="No Knowledge"
               key="No Knowledge"
-              className="py-2"
+              className="py-2 hover:cursor-default text-foreground-400"
               content="No Knowledge"
               isReadOnly
             >

--- a/components/scripts/tool-dropdown.tsx
+++ b/components/scripts/tool-dropdown.tsx
@@ -110,7 +110,7 @@ const ScriptToolsDropdown = () => {
                   aria-label="No tools"
                   color="primary"
                   key="No tools"
-                  className="py-2 hover:cursor-default"
+                  className="py-2 hover:cursor-default text-foreground-400"
                   content="No tools"
                   isReadOnly
                 >
@@ -143,7 +143,7 @@ const ScriptToolsDropdown = () => {
                 aria-label="No tools"
                 color="danger"
                 key="No tools"
-                className="py-2"
+                className="py-2 hover:cursor-default text-foreground-400"
                 content="No tools"
                 isReadOnly
               >


### PR DESCRIPTION
In the corresponding dropdowns, this change adjusts the text color for "No Tools" and "No Knowledge" to be lighter.