### PR TITLE
fix: clear tools when new thread is created

### DIFF
--- a/server/app.mjs
+++ b/server/app.mjs
@@ -165,13 +165,14 @@ const mount = async (
               break;
             }
           }
-          socket.emit('loaded', {
-            messages: state.messages,
-            tools: state.tools || [],
-          });
         }
       }
     }
+
+    socket.emit('loaded', {
+      messages: state.messages ?? [],
+      tools: state.tools ?? [],
+    });
   } catch (e) {
     console.error('Error loading state:', e);
   }


### PR DESCRIPTION
When switching threads, the socket will send back the messages and tools for the thread. However, if the thread state file doesn't exist yet, nothing is sent. This leads to the tools being leftover from the previous thread.

This change will emit the event so that the tools are correctly set for a new thread.