### PR TITLE
Feat: Add knowledge first class support in Assistant

### DIFF
--- a/actions/knowledge/filehelper.ts
+++ b/actions/knowledge/filehelper.ts
@@ -1,0 +1,33 @@
+'use server';
+
+import fs from 'fs';
+import path from 'path';
+
+export async function getFileOrFolderSizeInKB(
+  filePath: string
+): Promise<number> {
+  const stats = fs.statSync(filePath);
+
+  if (stats.isFile()) {
+    // Convert file size from bytes to KB
+    return parseFloat((stats.size / 1024).toFixed(2));
+  }
+
+  if (stats.isDirectory()) {
+    const files = fs.readdirSync(filePath);
+    const folderSize = await Promise.all(
+      files.map(async (file) => {
+        const currentPath = path.join(filePath, file);
+        return await getFileOrFolderSizeInKB(currentPath);
+      })
+    ).then((sizes) => sizes.reduce((total, size) => total + size, 0));
+
+    return parseFloat(folderSize.toFixed(2));
+  }
+
+  return 0;
+}
+
+export async function getBasename(filePath: string): Promise<string> {
+  return path.basename(filePath);
+}

--- a/actions/knowledge/knowledge.ts
+++ b/actions/knowledge/knowledge.ts
@@ -1,7 +1,9 @@
 'use server';
+import fs from 'fs';
 import path from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { KNOWLEDGE_DIR } from '@/config/env';
 
 const execPromise = promisify(exec);
 
@@ -20,4 +22,121 @@ export async function ingest(
     { env: { ...process.env, GPTSCRIPT_GATEWAY_API_KEY: token } }
   );
   return;
+}
+
+export async function deleteDataset(datasetID: string): Promise<void> {
+  const datasetDir = path.join(KNOWLEDGE_DIR(), 'script_data', datasetID);
+  if (!fs.existsSync(datasetDir)) {
+    return;
+  }
+  await execPromise(`${process.env.KNOWLEDGE_BIN} delete-dataset ${datasetID}`);
+  await fs.promises.rm(datasetDir, {
+    recursive: true,
+    force: true,
+  });
+  return;
+}
+
+export async function ensureFilesIngested(
+  files: string[],
+  scriptId: string,
+  token: string
+) {
+  const dir = path.join(KNOWLEDGE_DIR(), 'script_data', scriptId, 'data');
+  if (!fs.existsSync(dir) && files.length > 0) {
+    fs.mkdirSync(dir, { recursive: true });
+  } else if (!fs.existsSync(dir) && files.length === 0) {
+    // if there are no files in the directory and no dropped files, do nothing
+    return;
+  }
+
+  for (const file of files) {
+    const filePath = path.join(dir, path.basename(file));
+    try {
+      if (!fs.existsSync(filePath)) {
+        await fs.promises.copyFile(file, filePath);
+      }
+    } catch (error) {
+      console.error(`Error copying file ${file}:`, error);
+      throw error;
+    }
+  }
+
+  try {
+    const filesInDir = await fs.promises.readdir(dir);
+    for (const fileName of filesInDir) {
+      const fullPath = path.join(dir, fileName);
+      const fileInDroppedFiles = files.find(
+        (file) => path.basename(file) === path.basename(fullPath)
+      );
+      if (!fileInDroppedFiles || !files || files.length === 0) {
+        await fs.promises.unlink(fullPath);
+      }
+    }
+  } catch (error) {
+    console.error('Error during cleanup of removed files:', error);
+    throw error;
+  }
+
+  try {
+    await runKnowledgeIngest(
+      scriptId,
+      path.join(KNOWLEDGE_DIR(), 'script_data', scriptId),
+      token
+    );
+  } catch (error) {
+    console.error('Error during ingestion:', error);
+    throw error;
+  }
+
+  return;
+}
+
+async function runKnowledgeIngest(
+  id: string,
+  knowledgePath: string,
+  token: string
+): Promise<void> {
+  try {
+    // Start the ingestion process in the background
+    await execPromise(
+      `${process.env.KNOWLEDGE_BIN} ingest --prune --dataset ${id} ./data`,
+      {
+        cwd: knowledgePath,
+        env: { ...process.env, GPTSCRIPT_GATEWAY_API_KEY: token },
+      }
+    );
+
+    const errorFilePath = path.join(knowledgePath, 'error.log');
+    if (fs.existsSync(errorFilePath)) {
+      await fs.promises.rm(errorFilePath);
+    }
+  } catch (error) {
+    console.log(error);
+    handleError(knowledgePath, error as Error);
+    throw error;
+  }
+}
+
+export async function getFiles(scriptId: string): Promise<string[]> {
+  const dir = path.join(KNOWLEDGE_DIR(), 'script_data', scriptId, 'data');
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+  const files = await fs.promises.readdir(dir);
+  return files.map((file) => path.join(dir, file));
+}
+
+export async function datasetExists(scriptId: string): Promise<boolean> {
+  const dir = path.join(KNOWLEDGE_DIR(), 'script_data', scriptId, 'data');
+  return fs.existsSync(dir);
+}
+
+export async function getKnowledgeBinaryPath(): Promise<string> {
+  return process.env.KNOWLEDGE_BIN || 'knowledge';
+}
+
+function handleError(dir: string, error: Error): void {
+  const errorFilePath = path.join(dir, 'error.log');
+  fs.writeFileSync(errorFilePath, error.message);
 }

--- a/components/edit/configure/imports.tsx
+++ b/components/edit/configure/imports.tsx
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useState } from 'react';
 import { Button } from '@nextui-org/react';
 import {
-  GoBook,
   GoBrowser,
   GoFileDirectory,
   GoGlobe,
@@ -249,8 +248,6 @@ const iconForTool = (toolName: string | undefined) => {
       return <PiMicrosoftOutlookLogoDuotone className="text-md" />;
     case 'github.com/gptscript-ai/tools/apis/outlook/calendar/manage':
       return <PiMicrosoftOutlookLogoDuotone className="text-md" />;
-    case 'github.com/gptscript-ai/knowledge@v0.4.7-gateway':
-      return <GoBook className="text-md" />;
     case 'github.com/gptscript-ai/structured-data-querier':
       return <PiMicrosoftExcelLogo className="text-md" />;
     case 'github.com/gptscript-ai/json-query':

--- a/components/knowledge/KnowledgeModals.tsx
+++ b/components/knowledge/KnowledgeModals.tsx
@@ -1,0 +1,133 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Slider,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+} from '@nextui-org/react';
+import { BiPlus, BiTrash } from 'react-icons/bi';
+import { useContext } from 'react';
+import { EditContext } from '@/contexts/edit';
+
+interface KnowledgeProps {
+  isFileSettingOpen: boolean;
+  onFileSettingClose: () => void;
+  isFileTableOpen: boolean;
+  onFileTableClose: () => void;
+  handleAddFiles: () => void;
+}
+
+const KnowledgeModals = ({
+  isFileSettingOpen,
+  onFileSettingClose,
+  isFileTableOpen,
+  onFileTableClose,
+  handleAddFiles,
+}: KnowledgeProps) => {
+  const {
+    topK,
+    setTopK,
+    droppedFileDetails,
+    setDroppedFileDetails,
+    setDroppedFiles,
+  } = useContext(EditContext);
+  return (
+    <>
+      <Modal
+        size="sm"
+        backdrop="opaque"
+        isOpen={isFileSettingOpen}
+        onClose={onFileSettingClose}
+      >
+        <ModalContent>
+          <ModalHeader>Settings</ModalHeader>
+          <ModalBody>
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-zinc-500">{`Number of Results:`}</p>
+              <p className="text-sm text-zinc-500">{topK}</p>
+            </div>
+            <Slider
+              size="sm"
+              step={1}
+              value={topK}
+              minValue={0}
+              maxValue={50}
+              onChange={(value) => {
+                setTopK(value as number);
+              }}
+              aria-label="top-k"
+            />
+            <p className="text-sm text-zinc-500 pt-2">
+              Select the number of most relevant documents from a retrieved set,
+              based on their relevance scores
+            </p>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+      <Modal
+        size="xl"
+        backdrop="opaque"
+        isOpen={isFileTableOpen}
+        onClose={onFileTableClose}
+      >
+        <ModalContent>
+          <ModalHeader>
+            <h3 id="modal-title">Files</h3>
+          </ModalHeader>
+          <ModalBody>
+            <Table removeWrapper aria-label="File table">
+              <TableHeader>
+                <TableColumn>File Name</TableColumn>
+                <TableColumn>Size</TableColumn>
+                <TableColumn>{''}</TableColumn>
+              </TableHeader>
+              <TableBody>
+                {Array.from(droppedFileDetails).map((fileDetail, index) => (
+                  <TableRow key={index}>
+                    <TableCell>{fileDetail[1].fileName}</TableCell>
+                    <TableCell>{fileDetail[1].size} KB</TableCell>
+                    <TableCell align="right">
+                      <Button
+                        isIconOnly
+                        size="md"
+                        onClick={() => {
+                          setDroppedFiles((prev) =>
+                            prev.filter((f) => f !== fileDetail[0])
+                          );
+                          const newDetails = new Map(droppedFileDetails);
+                          newDetails.delete(fileDetail[0]);
+                          setDroppedFileDetails(newDetails);
+                        }}
+                        className="bg-white"
+                        startContent={<BiTrash />}
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              className="w-full"
+              onClick={handleAddFiles}
+              startContent={<BiPlus />}
+            >
+              Add files
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default KnowledgeModals;

--- a/components/scripts.tsx
+++ b/components/scripts.tsx
@@ -25,6 +25,7 @@ import { LuMessageSquare } from 'react-icons/lu';
 import { FaCopy } from 'react-icons/fa';
 import { Tool } from '@gptscript-ai/gptscript/src/gptscript';
 import { stringify } from '@/actions/gptscript';
+import { deleteDataset } from '@/actions/knowledge/knowledge';
 
 interface ScriptsProps {
   showFavorites?: boolean;
@@ -59,14 +60,14 @@ export default function Scripts({ showFavorites }: ScriptsProps) {
     setLoading(false);
   };
 
-  const handleDelete = useCallback((script: ParsedScript) => {
-    deleteScript(script)
-      .then(() => {
-        setScripts((scripts) =>
-          scripts.filter((currScript) => currScript.id !== script.id)
-        );
-      })
-      .catch((error) => console.error(error));
+  const handleDelete = useCallback(async (script: ParsedScript) => {
+    await deleteScript(script);
+    setScripts((scripts) =>
+      scripts.filter((currScript) => currScript.id !== script.id)
+    );
+    if (script.id) {
+      await deleteDataset(script.id.toString());
+    }
   }, []);
 
   const onClickCopy = async (script: ParsedScript) => {

--- a/config/env.ts
+++ b/config/env.ts
@@ -3,6 +3,8 @@ import path from 'path';
 
 export const SCRIPTS_PATH = () => process.env.SCRIPTS_PATH || 'gptscripts';
 export const WORKSPACE_DIR = () => process.env.WORKSPACE_DIR || '';
+export const KNOWLEDGE_DIR = () =>
+  process.env.KNOWLEDGE_DIR || path.join(WORKSPACE_DIR(), 'knowledge');
 export const THREADS_DIR = () =>
   process.env.THREADS_DIR || path.join(WORKSPACE_DIR(), 'threads');
 export const GATEWAY_URL = () =>


### PR DESCRIPTION
Note that this will have to be rebased once donnie's change is out.

The Server side implemetation:

1. For each assistant, we store all the files into ${DefaultWorkspace}/knowledge/{script_data}/{id}/data.
2. Once file is added, we copy the files over and run ingest with scriptID as dataset.
3. A knowledge tool will also be added into the script to run retrieval with the same scriptID.