### PR TITLE
Fix: fix mysterious digest error bug

### DIFF
--- a/contexts/edit.tsx
+++ b/contexts/edit.tsx
@@ -349,7 +349,7 @@ const EditContextProvider: React.FC<EditContextProps> = ({
   const update = useCallback(async () => {
     if (debounceTimer.current) clearTimeout(debounceTimer.current);
     debounceTimer.current = setTimeout(async () => {
-      if (scriptId && visibility && root) {
+      if (scriptId && visibility && root && root.name) {
         const existing = await getScript(scriptId.toString());
         const scriptTools = [root, ...tools];
         if (knowledgeTool.name) {


### PR DESCRIPTION
This should fix the bug 

```
2024-08-29T05:47:14.205Z [server] [ERROR]  ⨯ unhandledRejection: TypeError: Cannot read properties of undefined (reading 'digest')
    at /Users/daishan/work/ui/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:36:17710
    at AsyncLocalStorage.run (node:async_hooks:346:14)
    at eL (/Users/daishan/work/ui/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:273726)
    at /Users/daishan/work/ui/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:269554
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2024-08-29T05:47:14.206Z [server] [ERROR]  ⨯ unhandledRejection: TypeError: Cannot read properties of undefined (reading 'digest')
    at /Users/daishan/work/ui/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:36:17710
    at AsyncLocalStorage.run (node:async_hooks:346:14)
    at eL (/Users/daishan/work/ui/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:273726)
    at /Users/daishan/work/ui/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:269554
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This is because we are sending an empty tool to run stringify.

https://github.com/gptscript-ai/desktop/issues/257