### PR TITLE
Fix: cursor not going to the right after going to previous message

### DIFF
--- a/components/chat/chatBar.tsx
+++ b/components/chat/chatBar.tsx
@@ -166,8 +166,8 @@ const ChatBar = ({
                 setCommandsOpen(false);
               }
               if (event.key === 'ArrowUp') {
+                event.preventDefault();
                 if (commandsOpen) {
-                  event.preventDefault();
                   document.getElementById('command-0')?.focus();
                 } else {
                   setUserMessagesIndex((prevIndex) => {


### PR DESCRIPTION
This fixed an issue where you type ArrowUp and cursor is not moving to the right.