### PR TITLE
Fix: Move knowledge location for thread, delete dataset after thread deletion

### DIFF
--- a/actions/knowledge/knowledge.ts
+++ b/actions/knowledge/knowledge.ts
@@ -15,7 +15,7 @@ export async function ingest(
   if (!datasetID) {
     throw new Error('Dataset ID is required');
   }
-  const dir = path.join(workspace, 'knowledge');
+  const dir = path.join(path.dirname(workspace), 'knowledge');
   const knowledgeBinaryPath = process.env.KNOWLEDGE_BIN;
   await execPromise(
     `${knowledgeBinaryPath} ingest --prune --dataset ${datasetID} ${dir.replace(/ /g, '\\ ')}`,

--- a/actions/threads.tsx
+++ b/actions/threads.tsx
@@ -3,10 +3,15 @@
 import { THREADS_DIR, WORKSPACE_DIR } from '@/config/env';
 import { gpt } from '@/config/env';
 import fs from 'fs/promises';
+import { existsSync } from 'fs';
 import path from 'path';
+import { promisify } from 'util';
+import { exec } from 'child_process';
 
 const STATE_FILE = 'state.json';
 const META_FILE = 'meta.json';
+
+const execPromise = promisify(exec);
 
 export type Thread = {
   state: string;
@@ -131,6 +136,9 @@ export async function createThread(
 export async function deleteThread(id: string) {
   const threadsDir = THREADS_DIR();
   const threadPath = path.join(threadsDir, id);
+  if (existsSync(path.join(threadPath, 'knowledge'))) {
+    await execPromise(`${process.env.KNOWLEDGE_BIN} delete-dataset ${id}`);
+  }
   await fs.rm(threadPath, { recursive: true });
 }
 

--- a/actions/upload.tsx
+++ b/actions/upload.tsx
@@ -11,7 +11,7 @@ export async function uploadFile(
   isKnowledge?: boolean
 ) {
   if (isKnowledge) {
-    workspace = path.join(workspace, 'knowledge');
+    workspace = path.join(path.dirname(workspace), 'knowledge');
   }
   const file = formData.get('file') as File;
   await fs.mkdir(workspace, { recursive: true });
@@ -32,11 +32,11 @@ export async function deleteFile(path: string) {
 }
 
 export async function lsKnowledgeFiles(workspace: string): Promise<string> {
-  return lsFiles(path.join(workspace, 'knowledge'));
+  return lsFiles(path.join(path.dirname(workspace), 'knowledge'));
 }
 
 export async function deleteKnowledgeFile(workspace: string, name: string) {
-  return deleteFile(path.join(workspace, 'knowledge', name));
+  return deleteFile(path.join(path.dirname(workspace), 'knowledge', name));
 }
 
 export async function lsFiles(dir: string): Promise<string> {

--- a/components/threads/menu.tsx
+++ b/components/threads/menu.tsx
@@ -12,6 +12,7 @@ import {
   ModalHeader,
   ModalFooter,
   ModalBody,
+  Spinner,
 } from '@nextui-org/react';
 import { deleteThread, renameThread, Thread } from '@/actions/threads';
 import { GoPencil, GoTrash, GoKebabHorizontal } from 'react-icons/go';
@@ -27,14 +28,16 @@ const NewThread = ({ className, thread }: NewThreadProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { setThreads } = useContext(ChatContext);
+  const [isLoading, setIsLoading] = useState(false);
   const [threadNameInput, setThreadNameInput] = useState('');
 
-  const handleDeleteThread = () => {
-    deleteThread(thread).then(() => {
-      setThreads((threads: Thread[]) =>
-        threads.filter((t: Thread) => t.meta.id !== thread)
-      );
-    });
+  const handleDeleteThread = async () => {
+    setIsLoading(true);
+    await deleteThread(thread);
+    setThreads((threads: Thread[]) =>
+      threads.filter((t: Thread) => t.meta.id !== thread)
+    );
+    setIsLoading(false);
   };
 
   const handleRenameThread = (newName: string) => {
@@ -54,80 +57,86 @@ const NewThread = ({ className, thread }: NewThreadProps) => {
 
   return (
     <>
-      <Popover
-        placement="right-start"
-        isOpen={isPopoverOpen}
-        onOpenChange={(open) => setIsPopoverOpen(open)}
-      >
-        <PopoverTrigger>
-          <Button
-            variant="light"
-            radius="full"
-            className={`${className}`}
-            isIconOnly
-            startContent={<GoKebabHorizontal />}
-          />
-        </PopoverTrigger>
-        <PopoverContent className="">
-          <Menu aria-label="options">
-            <MenuItem
-              className="py-2"
-              content="Rename"
-              startContent={<GoPencil />}
-              onClick={() => {
-                setIsPopoverOpen(false);
-                onOpen();
-              }}
-            >
-              Rename
-            </MenuItem>
-            <MenuItem
-              aria-label="delete"
-              className="py-2"
-              content="Delete"
-              startContent={<GoTrash />}
-              onClick={() => {
-                setIsPopoverOpen(false);
-                handleDeleteThread();
-              }}
-            >
-              Delete
-            </MenuItem>
-          </Menu>
-        </PopoverContent>
-      </Popover>
-      <Modal
-        backdrop={'opaque'}
-        isOpen={isOpen}
-        onClose={onClose}
-        placement="top-center"
-      >
-        <ModalContent>
-          <ModalHeader className="flex flex-col gap-1">
-            Rename thread
-          </ModalHeader>
-          <ModalBody>
-            <Input
-              aria-label="rename"
-              label="New Name"
-              value={threadNameInput}
-              onChange={(e) => setThreadNameInput(e.target.value)}
-            />
-          </ModalBody>
-          <ModalFooter>
-            <Button
-              aria-label="rename"
-              color="primary"
-              onPress={() => {
-                handleRenameThread(threadNameInput);
-                onClose();
-              }}
-            >
-              Rename
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+      {isLoading ? (
+        <Spinner color="success" />
+      ) : (
+        <>
+          <Popover
+            placement="right-start"
+            isOpen={isPopoverOpen}
+            onOpenChange={(open) => setIsPopoverOpen(open)}
+          >
+            <PopoverTrigger>
+              <Button
+                variant="light"
+                radius="full"
+                className={`${className}`}
+                isIconOnly
+                startContent={<GoKebabHorizontal />}
+              />
+            </PopoverTrigger>
+            <PopoverContent className="">
+              <Menu aria-label="options">
+                <MenuItem
+                  className="py-2"
+                  content="Rename"
+                  startContent={<GoPencil />}
+                  onClick={() => {
+                    setIsPopoverOpen(false);
+                    onOpen();
+                  }}
+                >
+                  Rename
+                </MenuItem>
+                <MenuItem
+                  aria-label="delete"
+                  className="py-2"
+                  content="Delete"
+                  startContent={<GoTrash />}
+                  onClick={() => {
+                    setIsPopoverOpen(false);
+                    handleDeleteThread();
+                  }}
+                >
+                  Delete
+                </MenuItem>
+              </Menu>
+            </PopoverContent>
+          </Popover>
+          <Modal
+            backdrop={'opaque'}
+            isOpen={isOpen}
+            onClose={onClose}
+            placement="top-center"
+          >
+            <ModalContent>
+              <ModalHeader className="flex flex-col gap-1">
+                Rename thread
+              </ModalHeader>
+              <ModalBody>
+                <Input
+                  aria-label="rename"
+                  label="New Name"
+                  value={threadNameInput}
+                  onChange={(e) => setThreadNameInput(e.target.value)}
+                />
+              </ModalBody>
+              <ModalFooter>
+                <Button
+                  aria-label="rename"
+                  color="primary"
+                  onPress={() => {
+                    handleRenameThread(threadNameInput);
+                    onClose();
+                  }}
+                >
+                  Rename
+                </Button>
+              </ModalFooter>
+            </ModalContent>
+          </Modal>
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
This PR moves thread to {Thread_location}/${id}/knowledge to separate workspace from it per ask for craig. Also deletes the dataset when thread is deleted.