### PR TITLE
chore: check for "not text" instead of "tool"

### DIFF
--- a/actions/gptscript.tsx
+++ b/actions/gptscript.tsx
@@ -6,7 +6,7 @@ import { createAction } from '@/actions/helpers';
 
 export const rootTool = async (toolContent: Block[]): Promise<Tool> => {
   for (const block of toolContent) {
-    if (block.type === 'tool') return block;
+    if (block.type !== 'text') return block;
   }
   return {} as Tool;
 };
@@ -14,7 +14,7 @@ export const rootTool = async (toolContent: Block[]): Promise<Tool> => {
 export const parseContent = async (toolContent: string): Promise<Tool[]> => {
   const parsedTool = await gpt().parseContent(toolContent);
   return parsedTool.filter(
-    (block) => block.type === 'tool' && !block.name?.startsWith('metadata')
+    (block) => block.type !== 'text' && !block.name?.startsWith('metadata')
   ) as Tool[];
 };
 
@@ -25,7 +25,7 @@ export const parseBlock = createAction(async (ref: string) => {
 export const parse = async (file: string): Promise<Tool[]> => {
   const parsedTool = await gpt().parse(file);
   return parsedTool.filter(
-    (block) => block.type === 'tool' && !block.name?.startsWith('metadata')
+    (block) => block.type !== 'text' && !block.name?.startsWith('metadata')
   ) as Tool[];
 };
 

--- a/components/scripts.tsx
+++ b/components/scripts.tsx
@@ -79,7 +79,7 @@ export default function Scripts({ showFavorites }: ScriptsProps) {
       displayName: 'Copy of ' + script.agentName ?? script.displayName,
       visibility: 'private',
     };
-    if (script.script.length > 0 && script.script[0].type === 'tool') {
+    if (script.script.length > 0 && script.script[0].type !== 'text') {
       (script.script[0] as Tool).name = toCreate.displayName;
     }
     toCreate.content = await stringify(script.script);

--- a/components/scripts/script-save.tsx
+++ b/components/scripts/script-save.tsx
@@ -98,7 +98,7 @@ const SaveScriptDropdown = () => {
 
       if (
         !scriptContent.find(
-          (t) => t.type === 'tool' && t.name === KNOWLEDGE_NAME
+          (t) => t.type !== 'text' && t.name === KNOWLEDGE_NAME
         )
       ) {
         newKnowledgeToolBlock = await assistantKnowledgeTool(scriptID, 10);

--- a/contexts/edit.tsx
+++ b/contexts/edit.tsx
@@ -327,7 +327,7 @@ const EditContextProvider: React.FC<EditContextProps> = ({
         withoutRoot.splice(i, 1);
         break;
       }
-      return withoutRoot.filter((block) => block.type === 'tool') as Tool[];
+      return withoutRoot.filter((block) => block.type !== 'text') as Tool[];
     },
     [root]
   );

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -176,7 +176,7 @@ const mount = async (
 
     // also load the tools defined the states so that when running a thread that has tools added in state, we don't lose them
     for (let block of script) {
-      if (block.type === 'tool') {
+      if (block.type !== 'text') {
         block.tools = [
           ...new Set([...(block.tools || []), ...(state.tools || [])]),
         ];
@@ -267,7 +267,7 @@ const mount = async (
 
     // find the root tool and then add the new tool
     for (let block of script) {
-      if (block.type === 'tool') {
+      if (block.type !== 'text') {
         block.tools = [...new Set([...(block.tools || []), tool])];
         break;
       }
@@ -296,7 +296,7 @@ const mount = async (
 
     // find the root tool and then remove the tool
     for (let block of script) {
-      if (block.type === 'tool') {
+      if (block.type !== 'text') {
         if (block.tools) {
           block.tools = [...new Set(block.tools.filter((t) => t !== tool))];
         }
@@ -325,7 +325,7 @@ const mount = async (
 
     state.tools = [];
     for (let block of script) {
-      if (block.type === 'tool') {
+      if (block.type !== 'text') {
         block.name = newName || block.name;
         block.tools = [
           ...new Set([
@@ -335,7 +335,7 @@ const mount = async (
         if (extraTools) {
           script = [...script, ...extraTools];
           block.tools.push(
-            ...extraTools.filter((t) => t.type === 'tool').map((t) => t.name)
+            ...extraTools.filter((t) => t.type !== 'text').map((t) => t.name)
           );
         }
         break;


### PR DESCRIPTION
Now that tools can have different types, checking for type "tool" is not correct. Instead, check for type being not text.