### PR TITLE
fix: disable chat input any time we are waiting for a prompt response

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -64,6 +64,7 @@ const Chat: React.FC<ScriptProps> = ({
     notFound,
     restartScript,
     fetchThreads,
+    waitingForUserResponse,
   } = useContext(ChatContext);
 
   useEffect(() => {
@@ -171,7 +172,9 @@ const Chat: React.FC<ScriptProps> = ({
               </Button>
             ) : (
               <ChatBar
-                disableInput={disableInput || !running}
+                disableInput={
+                  disableInput || !running || waitingForUserResponse
+                }
                 disableCommands={disableCommands}
                 inputPlaceholder={inputPlaceholder}
                 onMessageSent={handleMessageSent}

--- a/components/chat/chatBar.tsx
+++ b/components/chat/chatBar.tsx
@@ -38,6 +38,7 @@ const ChatBar = ({
     setShowForm,
     messages,
     setMessages,
+    waitingForUserResponse,
   } = useContext(ChatContext);
 
   const messagesRef = useRef(messages);
@@ -133,6 +134,7 @@ const ChatBar = ({
           radius="full"
           className="text-lg"
           color="primary"
+          disabled={disableInput}
           onPress={() => {
             if (disableInput) return;
             setCommandsOpen(true);
@@ -160,8 +162,10 @@ const ChatBar = ({
             placeholder={
               catalogOpen
                 ? 'Search for tools to add or press <Esc> to return to the chat'
-                : inputPlaceholder ||
-                  'Start chatting or type / for more options'
+                : disableInput
+                  ? 'Waiting for a response to a prompt in chat...'
+                  : inputPlaceholder ||
+                    'Start chatting or type / for more options'
             }
             value={inputValue}
             radius="full"
@@ -218,7 +222,7 @@ const ChatBar = ({
           startContent={<GoSquareFill className="mr-[1px] text-xl" />}
           isIconOnly
           radius="full"
-          isDisabled={disableInput}
+          isDisabled={disableInput && !waitingForUserResponse}
           className="text-lg"
           onPress={interrupt}
         />

--- a/contexts/chat.tsx
+++ b/contexts/chat.tsx
@@ -14,7 +14,6 @@ import { getScript, getScriptContent } from '@/actions/me/scripts';
 import { loadTools, parseContent, rootTool } from '@/actions/gptscript';
 import debounce from 'lodash/debounce';
 import { setWorkspaceDir } from '@/actions/workspace';
-import { gatewayTool } from '@/actions/knowledge/util';
 import { tildy } from '@/config/assistant';
 
 interface ChatContextProps {
@@ -67,6 +66,7 @@ interface ChatContextState {
   generating: boolean;
   error: string | null;
   setShouldRestart: React.Dispatch<React.SetStateAction<boolean>>;
+  waitingForUserResponse: boolean;
 
   restart: () => void;
   interrupt: () => void;
@@ -117,6 +117,7 @@ const ChatContextProvider: React.FC<ChatContextProps> = ({
     setScriptContent,
     forceRun,
     setForceRun,
+    waitingForUserResponse,
   } = useChatSocket(isEmpty);
   const [scriptDisplayName, setScriptDisplayName] = useState<string>('');
   const threadInitialized = useRef(false);
@@ -385,6 +386,7 @@ const ChatContextProvider: React.FC<ChatContextProps> = ({
         fetchThreads,
         restartScript,
         setShouldRestart,
+        waitingForUserResponse,
         tools,
         setTools,
         handleCreateThread,


### PR DESCRIPTION
If the application is waiting for a prompt response (either prompt or confirmation), then this change will disable the chat input and use a placeholder to indicate that the application is waiting for a response.