### PR TITLE
fix: ensure that runs are stopped when switch threads

### DIFF
--- a/components/chat/chatBar/commands.tsx
+++ b/components/chat/chatBar/commands.tsx
@@ -135,14 +135,8 @@ export default forwardRef<ChatCommandsRef, CommandsProps>(
     const [filteredOptions, setFilteredOptions] =
       useState<typeof options>(options);
 
-    const {
-      restartScript,
-      socket,
-      setMessages,
-      tools,
-      workspace,
-      selectedThreadId,
-    } = useContext(ChatContext);
+    const { restartScript, socket, setMessages, tools, workspace, thread } =
+      useContext(ChatContext);
     const { openFilePicker, filesContent, loading, plainFiles } = useFilePicker(
       {}
     );
@@ -190,7 +184,7 @@ export default forwardRef<ChatCommandsRef, CommandsProps>(
             ]);
             await uploadFile(workspace, formData, true);
           }
-          await ingest(workspace, getCookie('gateway_token'), selectedThreadId);
+          await ingest(workspace, getCookie('gateway_token'), thread);
           setMessages((prev) => [
             ...prev,
             {

--- a/components/chat/chatBar/upload/workspace.tsx
+++ b/components/chat/chatBar/upload/workspace.tsx
@@ -17,7 +17,7 @@ interface WorkspaceProps {
 
 const Workspace = ({ onRestart }: WorkspaceProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { workspace, setWorkspace, selectedThreadId } = useContext(ChatContext);
+  const { workspace, setWorkspace, thread } = useContext(ChatContext);
   const [workspaceInput, setWorkspaceInput] = useState<string>('');
 
   useEffect(() => {
@@ -30,8 +30,8 @@ const Workspace = ({ onRestart }: WorkspaceProps) => {
     setWorkspace(workspaceInput);
     setIsOpen(false);
     // Here we use selectedThreadId here because it is always set after thread is created. Thread might not be set when it is created on the fly.
-    if (selectedThreadId) {
-      updateThreadWorkspace(selectedThreadId, workspace);
+    if (thread) {
+      updateThreadWorkspace(thread, workspace);
     }
     onRestart();
   }, [workspaceInput]);

--- a/components/scripts/knowledge-dropdown.tsx
+++ b/components/scripts/knowledge-dropdown.tsx
@@ -18,14 +18,8 @@ import { Dirent } from 'fs';
 import path from 'path';
 
 const ScriptKnowledgeDropdown = () => {
-  const {
-    socket,
-    scriptId,
-    workspace,
-    selectedThreadId,
-    program,
-    setMessages,
-  } = useContext(ChatContext);
+  const { socket, scriptId, workspace, thread, program, setMessages } =
+    useContext(ChatContext);
   const [threadKnowledgeFiles, setThreadKnowledgeFiles] = useState<string[]>(
     []
   );
@@ -57,7 +51,7 @@ const ScriptKnowledgeDropdown = () => {
 
   async function removeFile(file: string) {
     await deleteKnowledgeFile(workspace, file);
-    await ingest(workspace, getCookie('gateway_token'), selectedThreadId);
+    await ingest(workspace, getCookie('gateway_token'), thread);
     setMessages((prev) => [
       ...prev,
       {

--- a/components/scripts/script-save.tsx
+++ b/components/scripts/script-save.tsx
@@ -30,7 +30,7 @@ import { GoPaperclip } from 'react-icons/go';
 const SaveScriptDropdown = () => {
   const {
     workspace,
-    selectedThreadId,
+    thread,
     scriptId,
     setScriptId,
     setScript,
@@ -137,11 +137,7 @@ const SaveScriptDropdown = () => {
 
       socket?.emit('saveScript', newScriptId, newName);
 
-      await updateThreadScript(
-        selectedThreadId!,
-        newScriptId,
-        newScript.publicURL || ''
-      );
+      await updateThreadScript(thread, newScriptId, newScript.publicURL || '');
 
       setMessages((prev) => [
         ...prev,

--- a/components/threads.tsx
+++ b/components/threads.tsx
@@ -5,6 +5,7 @@ import { Button, Divider, Tooltip } from '@nextui-org/react';
 import { GoSidebarExpand, GoSidebarCollapse } from 'react-icons/go';
 import { ChatContext } from '@/contexts/chat';
 import { getScript } from '@/actions/me/scripts';
+import { Message } from '@/components/chat/messages';
 
 interface ThreadsProps {
   className?: string;
@@ -15,26 +16,30 @@ const Threads: React.FC<ThreadsProps> = ({ onOpenExplore }: ThreadsProps) => {
   const {
     setScript,
     setScriptContent,
+    thread,
     setThread,
     threads,
     setScriptId,
-    selectedThreadId,
-    setSelectedThreadId,
     setShouldRestart,
+    setMessages,
   } = useContext(ChatContext);
 
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   const handleRun = async (script: string, id: string, scriptId: string) => {
-    setScriptContent((await getScript(scriptId))?.script || []);
-    setScript(script);
-    setThread(id);
-    setScriptId(scriptId);
-    setSelectedThreadId(id);
-    setShouldRestart(true);
+    if (id !== thread) {
+      setScriptContent((await getScript(scriptId))?.script || []);
+      setScript(script);
+      setThread(id);
+      setScriptId(scriptId);
+      setShouldRestart(true);
+      // Remove the messages from the screen immediately so the user has feedback that something is happening.
+      // We can't set the messages here to [] because that was cause the "Waiting for model response" message to show up.
+      setMessages([{} as Message]);
+    }
   };
 
-  const isSelected = (id: string) => id === selectedThreadId;
+  const isSelected = (id: string) => id === thread;
 
   return (
     <div


### PR DESCRIPTION
This change will ensure that currently running gptscript runs are stopped when switching threads. Additionally, this change removes the redundant selectedThreadId state because it is the same as thread.

Finally, we stop displaying the "run aborted" errors to the user because it isn't really an error: the user has chosen to abort the run.