### PR TITLE
fix: ensure the chat state is set when adding/removing tools

### DIFF
--- a/server/app.mjs
+++ b/server/app.mjs
@@ -375,6 +375,7 @@ const mount = async (
     let name = script[0].name || '';
     if (!runningScript) {
       opts.input = message;
+      opts.chatState = state.chatState;
       runningScript = await gptscript.evaluate(script, opts);
     } else {
       name = (runningScript.respondingTool() || {}).name || '';


### PR DESCRIPTION
When we add or remove a tool, the runningScript is set to null. In this case, we should ensure that the chat state is set.