### PR TITLE
Fix: make sure script id is always set

### DIFF
--- a/components/chat/chatBar.tsx
+++ b/components/chat/chatBar.tsx
@@ -186,12 +186,11 @@ const ChatBar = ({
                 document.getElementById('chatInput')?.focus();
               }
               if (event.key === 'ArrowUp') {
+                event.preventDefault();
                 const catalogStart = document.getElementById(`catalog-item-0`);
                 if (commandsOpen) {
-                  event.preventDefault();
                   commandsRef.current?.focusCommands();
                 } else if (catalogStart) {
-                  event.preventDefault();
                   commandsRef.current?.focusCatalog();
                 } else {
                   setUserMessagesIndex((prevIndex) => {

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -153,7 +153,7 @@ const mount = async (
       // Here we need to pass a fake GPTSCRIPT_THREAD_ID so that knowledge tool doesn't error out. Because it will always look for GPTSCRIPT_THREAD_ID in the env
       // It should not import anything from the env. This is the case where you chat in Edit Assistant page where thread is not enabled.
       'GPTSCRIPT_THREAD_ID=' + (threadID ? threadID : '0'),
-      'GPTSCRIPT_SCRIPT_ID=' + scriptID,
+      'GPTSCRIPT_SCRIPT_ID=' + (scriptID ? scriptID : '0'),
     ],
   };
 


### PR DESCRIPTION
When adding files through Tildy, there is no script id so make sure it always gets set. Knowledge requires both environmental variables to be set.

https://github.com/gptscript-ai/desktop/issues/421