### PR TITLE
fix: add immediate temp response when user sends a message

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -118,6 +118,7 @@ const Chat: React.FC<ScriptProps> = ({
     setMessages((prevMessages) => [
       ...prevMessages,
       { type: MessageType.User, message },
+      { type: MessageType.Agent, message: 'Waiting for model response...' },
     ]);
     if (hasNoUserMessages() && thread) {
       renameThread(thread, await generateThreadName(message));

--- a/components/chat/useChatSocket.tsx
+++ b/components/chat/useChatSocket.tsx
@@ -118,24 +118,16 @@ const useChatSocket = (isEmpty?: boolean) => {
         calls: state,
         name: name,
       };
-      if (latestAgentMessageIndex.current === -1) {
-        latestAgentMessageIndex.current = messagesRef.current.length;
-        setMessages((prevMessages) => {
-          const updatedMessages = [...prevMessages];
-          updatedMessages.push(message);
-          return updatedMessages;
-        });
-      } else {
-        setMessages((prevMessages) => {
-          const updatedMessages = [...prevMessages];
-          if (latestAgentMessageIndex.current !== -1) {
-            updatedMessages[latestAgentMessageIndex.current] = message;
-          } else {
-            updatedMessages[messagesRef.current.length - 1] = message;
-          }
-          return updatedMessages;
-        });
-      }
+
+      setMessages((prevMessages) => {
+        const updatedMessages = [...prevMessages];
+        if (latestAgentMessageIndex.current !== -1) {
+          updatedMessages[latestAgentMessageIndex.current] = message;
+        } else {
+          updatedMessages[messagesRef.current.length - 1] = message;
+        }
+        return updatedMessages;
+      });
 
       if (isMainContent && frame.type == 'callFinish') {
         setGenerating(false);


### PR DESCRIPTION
Fixing this issue by adding an immediate temporary message whenever a user sends a message. This give the illusion that we're responding faster but really we're just adding an empty message immediately.

The result looks something like this.

https://github.com/user-attachments/assets/a8d5dac9-d0d2-433b-882d-c876269bfbb5

