### PR TITLE
WIP feat: update default assistant name to [Deleted Assistant]

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,27 +1,26 @@
 'use client';
 
-import React, {
-  useContext,
-  useEffect,
-  useState,
-  useRef,
-  useCallback,
-} from 'react';
-import Messages, { MessageType } from '@/components/chat/messages';
+import { getGatewayUrl } from '@/actions/gateway';
+import { rootTool } from '@/actions/gptscript';
+import { generateThreadName, renameThread } from '@/actions/threads';
+import { getWorkspaceDir } from '@/actions/workspace';
 import ChatBar from '@/components/chat/chatBar';
 import ToolForm from '@/components/chat/form';
+import Messages, { MessageType } from '@/components/chat/messages';
 import Loading from '@/components/loading';
-import { Button } from '@nextui-org/react';
-import { getWorkspaceDir } from '@/actions/workspace';
-import { getGatewayUrl } from '@/actions/gateway';
-import { ChatContext } from '@/contexts/chat';
-import ScriptToolsDropdown from '@/components/scripts/tool-dropdown';
-import AssistantNotFound from '@/components/assistant-not-found';
-import { generateThreadName, renameThread } from '@/actions/threads';
 import KnowledgeDropdown from '@/components/scripts/knowledge-dropdown';
 import SaveScriptDropdown from '@/components/scripts/script-save';
+import ScriptToolsDropdown from '@/components/scripts/tool-dropdown';
+import { ChatContext } from '@/contexts/chat';
 import { Tool } from '@gptscript-ai/gptscript';
-import { rootTool } from '@/actions/gptscript';
+import { Button } from '@nextui-org/react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 interface ScriptProps {
   className?: string;
@@ -155,11 +154,13 @@ const Chat: React.FC<ScriptProps> = ({
                     <h1 className="text-3xl font-medium truncate">
                       {scriptDisplayName ?? ''}
                     </h1>
-                    <div className="flex gap-2">
-                      <ScriptToolsDropdown />
-                      <KnowledgeDropdown />
-                      <SaveScriptDropdown />
-                    </div>
+                    {!notFound && (
+                      <div className="flex gap-2">
+                        <ScriptToolsDropdown />
+                        <KnowledgeDropdown />
+                        <SaveScriptDropdown />
+                      </div>
+                    )}
                   </div>
                 )}
                 <Messages
@@ -183,19 +184,21 @@ const Chat: React.FC<ScriptProps> = ({
                 {tool.chat ? 'Start chat' : 'Run script'}
               </Button>
             ) : (
-              <ChatBar
-                disableInput={
-                  disableInput || !running || waitingForUserResponse
-                }
-                disableCommands={disableCommands}
-                inputPlaceholder={inputPlaceholder}
-                onMessageSent={handleMessageSent}
-              />
+              <>
+                {!notFound && (
+                  <ChatBar
+                    disableInput={
+                      disableInput || !running || waitingForUserResponse
+                    }
+                    disableCommands={disableCommands}
+                    inputPlaceholder={inputPlaceholder}
+                    onMessageSent={handleMessageSent}
+                  />
+                )}
+              </>
             )}
           </div>
         </>
-      ) : notFound ? (
-        <AssistantNotFound />
       ) : (
         <Loading>Loading your assistant...</Loading>
       )}

--- a/components/threads.tsx
+++ b/components/threads.tsx
@@ -1,10 +1,9 @@
-import { useState, useContext } from 'react';
-import New from './threads/new';
-import Menu from './threads/menu';
-import { Button, Divider, Tooltip } from '@nextui-org/react';
-import { GoSidebarExpand, GoSidebarCollapse } from 'react-icons/go';
 import { ChatContext } from '@/contexts/chat';
-import { getScript } from '@/actions/me/scripts';
+import { Button, Divider, Tooltip } from '@nextui-org/react';
+import { useContext, useState } from 'react';
+import { GoSidebarCollapse, GoSidebarExpand } from 'react-icons/go';
+import Menu from './threads/menu';
+import New from './threads/new';
 
 interface ThreadsProps {
   className?: string;
@@ -12,27 +11,9 @@ interface ThreadsProps {
 }
 
 const Threads: React.FC<ThreadsProps> = ({ onOpenExplore }: ThreadsProps) => {
-  const {
-    setScript,
-    setScriptContent,
-    thread,
-    setThread,
-    threads,
-    setScriptId,
-    setShouldRestart,
-  } = useContext(ChatContext);
+  const { thread, threads, switchToThread } = useContext(ChatContext);
 
   const [isCollapsed, setIsCollapsed] = useState(false);
-
-  const handleRun = async (script: string, id: string, scriptId: string) => {
-    if (id !== thread) {
-      setScriptContent((await getScript(scriptId))?.script || []);
-      setScript(script);
-      setThread(id);
-      setScriptId(scriptId);
-      setShouldRestart(true);
-    }
-  };
 
   const isSelected = (id: string) => id === thread;
 
@@ -90,7 +71,7 @@ const Threads: React.FC<ThreadsProps> = ({ onOpenExplore }: ThreadsProps) => {
                     key={key}
                     className={`border-1 border-gray-300 px-4 rounded-xl transition duration-150 ease-in-out ${isSelected(thread.meta.id) ? 'bg-primary border-primary dark:border-primary-50 dark:bg-primary-50 text-white' : 'hover:bg-gray-100 dark:hover:bg-zinc-700 cursor-pointer dark:bg-zinc-800 dark:border-zinc-800'} `}
                     onClick={() =>
-                      handleRun(
+                      switchToThread(
                         thread.meta.script,
                         thread.meta.id,
                         thread.meta.scriptId || ''

--- a/contexts/chat.tsx
+++ b/contexts/chat.tsx
@@ -137,8 +137,8 @@ const ChatContextProvider: React.FC<ChatContextProps> = ({
       setThread(id);
       setScriptContent((await getScript(scriptId))?.script || []);
       setScriptId(scriptId);
+      // use `setForceRun` instead of `setShouldRestart` because it triggers the `run` WS event which will reset the messages as well
       setForceRun(true);
-      setShouldRestart(true);
     }
   };
 

--- a/contexts/chat.tsx
+++ b/contexts/chat.tsx
@@ -78,7 +78,7 @@ interface ChatContextState {
 }
 
 const defaultScriptName = `Tildy`;
-const notFoundScriptName = `[Deleted Assistant]`;
+const notFoundScriptName = `[Assistant Not Found]`;
 
 const ChatContext = createContext<ChatContextState>({} as ChatContextState);
 const ChatContextProvider: React.FC<ChatContextProps> = ({

--- a/contexts/chat.tsx
+++ b/contexts/chat.tsx
@@ -245,7 +245,7 @@ const ChatContextProvider: React.FC<ChatContextProps> = ({
           setInitialFetch(false);
           setWorkspace(thread.meta.workspace);
         }
-        // need to wait for the WS Server to restart befgore triggering another event
+        // need to wait for the WS Server to restart before triggering another event
         await restartScript();
         setShouldRestart(false);
       });

--- a/contexts/chat.tsx
+++ b/contexts/chat.tsx
@@ -72,7 +72,7 @@ interface ChatContextState {
   restartScript: () => void;
 }
 
-const defaultScriptName = `Tildy`;
+const defaultScriptName = `[Deleted Assistant]`;
 
 const ChatContext = createContext<ChatContextState>({} as ChatContextState);
 const ChatContextProvider: React.FC<ChatContextProps> = ({


### PR DESCRIPTION
Upon deleting an assistant, any left over chats with that assistant will be displayed in a read only state.

#90 

While making this change, I discovered a bug where switching threads causes the websocket server to restart, but does not wait for the server to come back up before relaying new messages. It wasn't apparent until I started making my changes and should not cause any issues after this PR. 