### PR TITLE
fix: reset tools when creating a thread

### DIFF
--- a/contexts/chat.tsx
+++ b/contexts/chat.tsx
@@ -328,6 +328,7 @@ const ChatContextProvider: React.FC<ChatContextProps> = ({
 
   const handleCreateThread = (script: string, id?: string) => {
     createThread(script, '', id).then((newThread) => {
+      setTools([]);
       setScriptId(id);
       setThreads((threads: Thread[]) => [newThread, ...threads]);
       setScript(script);


### PR DESCRIPTION
If this is not reset, then the tools from the previous selected thread will be leftover, but not actually available to the thread.