### PR TITLE
change: upgrade knowledge to v0.4.13 to include fixes

### DIFF
--- a/actions/knowledge/util.ts
+++ b/actions/knowledge/util.ts
@@ -1,5 +1,5 @@
 export function gatewayTool(): string {
-  return 'github.com/gptscript-ai/knowledge/gateway@v0.4.12';
+  return 'github.com/gptscript-ai/knowledge/gateway@v0.4.13';
 }
 
 // This is a bit hacky because we need to make sure that the knowledge tool is updated to the latest version.

--- a/scripts/install-binary.mjs
+++ b/scripts/install-binary.mjs
@@ -84,7 +84,7 @@ if (process.platform === 'win32') {
 const gptscript_info = {
   name: 'gptscript',
   url: 'https://github.com/gptscript-ai/knowledge/releases/download/',
-  version: 'v0.4.12',
+  version: 'v0.4.13',
 };
 
 const pltfm = {


### PR DESCRIPTION
## What's Changed
* fix: queryrelevancy prompt by @iwilltry42 in https://github.com/gptscript-ai/knowledge/pull/104
* fix: debug mode flag + bm25 silence no docs err + keepMin option for threshold post-processor by @iwilltry42 in https://github.com/gptscript-ai/knowledge/pull/105
* fix: do not min/max-normalize already normalized similarity scores to not distort them by @iwilltry42 in https://github.com/gptscript-ai/knowledge/pull/107
* change: bump chromem-go fork dep to include openai embedding retries by @iwilltry42 in https://github.com/gptscript-ai/knowledge/pull/108

Ref https://github.com/gptscript-ai/desktop/issues/425 & https://github.com/gptscript-ai/desktop/issues/264 & https://github.com/gptscript-ai/desktop/issues/275