### PR TITLE
fix: improve multiple prompts

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -117,13 +117,15 @@ const Chat: React.FC<ScriptProps> = ({
   const handleMessageSent = async (message: string) => {
     if (!socket || !connected) return;
 
-    setMessages((prevMessages) => [
-      ...prevMessages,
-      { type: MessageType.User, message },
-    ]);
-    setLatestAgentMessage({
-      type: MessageType.Agent,
-      message: 'Waiting for model response...',
+    setMessages((prevMessages) => {
+      setLatestAgentMessage({
+        type: MessageType.Agent,
+        message: 'Waiting for model response...',
+        name: prevMessages
+          ? prevMessages[prevMessages.length - 1].name
+          : undefined,
+      });
+      return [...prevMessages, { type: MessageType.User, message }];
     });
     if (hasNoUserMessages() && thread) {
       renameThread(thread, await generateThreadName(message));

--- a/components/chat/messages/confirmForm.tsx
+++ b/components/chat/messages/confirmForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { GoCheckCircle, GoXCircle, GoCheckCircleFill } from 'react-icons/go';
 import type { AuthResponse } from '@gptscript-ai/gptscript';
 import { Button, Code, Tooltip } from '@nextui-org/react';
@@ -21,20 +21,9 @@ const ConfirmForm = ({
   message,
   command,
 }: ConfirmFormProps) => {
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    setLoading(false);
-  }, [id]);
-
   const onSubmitForm = (accept: boolean) => {
-    setLoading(true);
     onSubmit({ id, message: `denied by user`, accept });
   };
-
-  if (loading) {
-    return null;
-  }
 
   return (
     <form>

--- a/components/chat/messages/promptForm.tsx
+++ b/components/chat/messages/promptForm.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { GoCheckCircle } from 'react-icons/go';
 import type { PromptFrame, PromptResponse } from '@gptscript-ai/gptscript';
@@ -13,15 +12,12 @@ const PromptForm = ({
 }) => {
   const { register, handleSubmit, getValues } =
     useForm<Record<string, string>>();
-  const [submitted, setSubmitted] = useState(false);
-
   const noFields = !frame.fields || frame.fields.length === 0;
   if (noFields) {
     frame.fields = [];
   }
 
   const onSubmitForm = () => {
-    setSubmitted(true);
     onSubmit({ id: frame.id, responses: getValues() });
     if (frame.metadata && frame.metadata.authURL) {
       open(frame.metadata.authURL);
@@ -64,9 +60,8 @@ const PromptForm = ({
         className="mb-6 w-full"
         size="lg"
         color="primary"
-        isDisabled={submitted}
       >
-        {submitted ? 'Submitted' : buttonText}
+        {buttonText}
       </Button>
     </form>
   );

--- a/contexts/chat.tsx
+++ b/contexts/chat.tsx
@@ -47,8 +47,6 @@ interface ChatContextState {
   setHasRun: React.Dispatch<React.SetStateAction<boolean>>;
   hasParams: boolean;
   setHasParams: React.Dispatch<React.SetStateAction<boolean>>;
-  isEmpty: boolean;
-  setIsEmpty: React.Dispatch<React.SetStateAction<boolean>>;
   notFound: boolean;
   setNotFound: React.Dispatch<React.SetStateAction<boolean>>;
   latestAgentMessage: Message;
@@ -93,7 +91,6 @@ const ChatContextProvider: React.FC<ChatContextProps> = ({
   const [scriptId, setScriptId] = useState<string | undefined>(initialScriptId);
   const [hasRun, setHasRun] = useState(false);
   const [hasParams, setHasParams] = useState(false);
-  const [isEmpty, setIsEmpty] = useState(false);
   const [notFound, setNotFound] = useState(false);
   const [thread, setThread] = useState<string>('');
   const [threads, setThreads] = useState<Thread[]>([]);
@@ -119,7 +116,7 @@ const ChatContextProvider: React.FC<ChatContextProps> = ({
     forceRun,
     setForceRun,
     waitingForUserResponse,
-  } = useChatSocket(isEmpty);
+  } = useChatSocket();
   const [scriptDisplayName, setScriptDisplayName] = useState<string>('');
   const threadInitialized = useRef(false);
   const [shouldRestart, setShouldRestart] = useState(false);
@@ -234,7 +231,6 @@ const ChatContextProvider: React.FC<ChatContextProps> = ({
   }, [subTool]);
 
   useEffect(() => {
-    setIsEmpty(!tool.instructions);
     if (
       hasRun ||
       !socket ||
@@ -365,8 +361,6 @@ const ChatContextProvider: React.FC<ChatContextProps> = ({
         setHasRun,
         hasParams,
         setHasParams,
-        isEmpty,
-        setIsEmpty,
         notFound,
         setNotFound,
         latestAgentMessage,


### PR DESCRIPTION
When a prompt was followed by another prompt, React was "helping" us by not completing resetting the state. This caused an issue where the old state would be used in the next prompt, making it appear as though the prompt was already submitted.

This change will reset this state so it will not be reused.

This change also includes some small changes around what is displayed before and after prompts. For example, when an authentication prompt disappeared, the message would still say,
"<Tool> needs to authenticate ." Now, the message will switch back to "Waiting for model response..."