### PR TITLE
fix: fetch threads after using "Save As" on a thread

### DIFF
--- a/components/scripts/script-save.tsx
+++ b/components/scripts/script-save.tsx
@@ -39,6 +39,7 @@ const SaveScriptDropdown = () => {
     scriptContent,
     setMessages,
     setHasRun,
+    fetchThreads,
   } = useContext(ChatContext);
 
   const [isOpen, setIsOpen] = useState(false);
@@ -150,6 +151,10 @@ const SaveScriptDropdown = () => {
       ]);
 
       setSuccessMessage(`New Assistant Saved As ${newScript.displayName}`);
+
+      // Fetch threads so that the state has the new assistant associated with the thread.
+      fetchThreads();
+
       await new Promise((resolve) => setTimeout(resolve, 3000));
 
       setScriptId(newScriptId);


### PR DESCRIPTION
When a user uses the "Save Assistant As" functionality, the new assistant they are creating is supposed to replace the current assistant in the thread. This was happening correctly.

However, the threads were being stored in state. Therefore, navigating away from the thread and coming back to it would make it look like the old assistant was still being used. This change will refresh the thread state after "Save Assistant As" so that the state will reflect the new assistant.