### PR TITLE
fix: address issues with how parameters work for subtools

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -30,6 +30,7 @@ interface ScriptProps {
   inputPlaceholder?: string;
   disableInput?: boolean;
   disableCommands?: boolean;
+  noChat?: boolean;
 }
 
 const Chat: React.FC<ScriptProps> = ({
@@ -39,6 +40,7 @@ const Chat: React.FC<ScriptProps> = ({
   inputPlaceholder,
   disableInput = false,
   disableCommands = false,
+  noChat = false,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, _setInputValue] = useState<string>('');
@@ -187,6 +189,7 @@ const Chat: React.FC<ScriptProps> = ({
                 disableInput={
                   disableInput || !running || waitingForUserResponse
                 }
+                noChat={noChat}
                 disableCommands={disableCommands}
                 inputPlaceholder={inputPlaceholder}
                 onMessageSent={handleMessageSent}

--- a/components/chat/chatBar.tsx
+++ b/components/chat/chatBar.tsx
@@ -155,9 +155,9 @@ const ChatBar = ({
             radius="full"
             className="text-lg"
             color="primary"
-            disabled={disableInput}
+            disabled={disableInput || noChat}
             onPress={() => {
-              if (disableInput) return;
+              if (disableInput || noChat) return;
               setCommandsOpen(true);
             }}
             onBlur={() => setTimeout(() => setCommandsOpen(false), 300)} // super hacky but it does work
@@ -177,13 +177,13 @@ const ChatBar = ({
           <Textarea
             ref={inputRef}
             color="primary"
-            isDisabled={disableInput}
+            isDisabled={disableInput || noChat}
             id="chatInput"
             autoComplete="off"
             placeholder={
               catalogOpen
                 ? 'Search for tools to add or press <Esc> to return to the chat'
-                : disableInput
+                : disableInput || noChat
                   ? 'Waiting for a response to a prompt in chat...'
                   : inputPlaceholder ||
                     'Start chatting or type / for more options'

--- a/components/chat/chatBar.tsx
+++ b/components/chat/chatBar.tsx
@@ -2,11 +2,15 @@
 
 import React, { useState, useContext, useEffect, useMemo, useRef } from 'react';
 import { IoMdSend } from 'react-icons/io';
-import { Spinner } from '@nextui-org/react';
+import { Spinner, Tooltip } from '@nextui-org/react';
 import { FaBackward } from 'react-icons/fa';
 import { Button, Textarea } from '@nextui-org/react';
 import Commands, { ChatCommandsRef } from '@/components/chat/chatBar/commands';
-import { GoKebabHorizontal, GoSquareFill } from 'react-icons/go';
+import {
+  GoIssueReopened,
+  GoKebabHorizontal,
+  GoSquareFill,
+} from 'react-icons/go';
 import { ChatContext } from '@/contexts/chat';
 import { MessageType } from '@/components/chat/messages';
 import { Tool } from '@gptscript-ai/gptscript';
@@ -16,12 +20,14 @@ interface ChatBarProps {
   disableInput?: boolean;
   disableCommands?: boolean;
   inputPlaceholder?: string;
+  noChat?: boolean;
   onMessageSent: (message: string) => void;
 }
 
 const ChatBar = ({
   disableInput = false,
   disableCommands = false,
+  noChat = false,
   inputPlaceholder,
   onMessageSent,
 }: ChatBarProps) => {
@@ -38,6 +44,7 @@ const ChatBar = ({
     setShowForm,
     messages,
     setMessages,
+    restartScript,
     waitingForUserResponse,
   } = useContext(ChatContext);
 
@@ -127,21 +134,35 @@ const ChatBar = ({
 
   return (
     <div className="flex px-4 space-x-2 sw-full">
-      {!disableCommands && (
-        <Button
-          isIconOnly
-          startContent={<GoKebabHorizontal />}
-          radius="full"
-          className="text-lg"
-          color="primary"
-          disabled={disableInput}
-          onPress={() => {
-            if (disableInput) return;
-            setCommandsOpen(true);
-          }}
-          onBlur={() => setTimeout(() => setCommandsOpen(false), 300)} // super hacky but it does work
-        />
-      )}
+      {!disableCommands &&
+        (noChat ? (
+          <Tooltip content="Restart script">
+            <Button
+              isIconOnly
+              startContent={<GoIssueReopened />}
+              radius="full"
+              className="text-lg"
+              color="primary"
+              onPress={() => {
+                restartScript();
+              }}
+            />
+          </Tooltip>
+        ) : (
+          <Button
+            isIconOnly
+            startContent={<GoKebabHorizontal />}
+            radius="full"
+            className="text-lg"
+            color="primary"
+            disabled={disableInput}
+            onPress={() => {
+              if (disableInput) return;
+              setCommandsOpen(true);
+            }}
+            onBlur={() => setTimeout(() => setCommandsOpen(false), 300)} // super hacky but it does work
+          />
+        ))}
       <div className="w-full relative">
         <Commands
           ref={commandsRef}
@@ -227,7 +248,7 @@ const ChatBar = ({
         />
       ) : (
         <>
-          {disableInput && !disableCommands ? (
+          {disableInput && !disableCommands && !noChat ? (
             <Spinner />
           ) : (
             <Button

--- a/components/edit/configure.tsx
+++ b/components/edit/configure.tsx
@@ -270,6 +270,7 @@ const Configure: React.FC<ConfigureProps> = ({ collapsed }) => {
               aria-label="advanced"
               title={<h1>Advanced</h1>}
               startContent={<HiCog />}
+              classNames={{ content: collapsed ? 'pt-6 pb-10' : 'p-10 pt-6' }}
             >
               <Models
                 options={models}

--- a/components/edit/configure/customTool.tsx
+++ b/components/edit/configure/customTool.tsx
@@ -385,7 +385,7 @@ const CustomTool: React.FC<ConfigureProps> = ({ tool }) => {
                   initialSubTool={customTool.name}
                   initialScriptId={`${scriptId}`}
                 >
-                  <Chat messagesHeight="h-[93%]" />
+                  <Chat disableInput={!customTool.chat} disableCommands={!customTool.chat} messagesHeight="h-[93%]" />
                 </ChatContextProvider>
               </div>
             </ModalBody>

--- a/components/edit/configure/customTool.tsx
+++ b/components/edit/configure/customTool.tsx
@@ -385,11 +385,7 @@ const CustomTool: React.FC<ConfigureProps> = ({ tool }) => {
                   initialSubTool={customTool.name}
                   initialScriptId={`${scriptId}`}
                 >
-                  <Chat
-                    disableInput={!customTool.chat}
-                    noChat={!customTool.chat}
-                    messagesHeight="h-[93%]"
-                  />
+                  <Chat noChat={!customTool.chat} messagesHeight="h-[93%]" />
                 </ChatContextProvider>
               </div>
             </ModalBody>

--- a/components/edit/configure/customTool.tsx
+++ b/components/edit/configure/customTool.tsx
@@ -183,7 +183,7 @@ const CustomTool: React.FC<ConfigureProps> = ({ tool }) => {
         >
           <ModalContent>
             <ModalBody className="grid grid-cols-2">
-              <div className="border-r-2 dark:border-zinc-700 pr-6 h-full overflow-y-auto">
+              <div className="border-r-2 dark:border-zinc-700 pr-6 h-full overflow-y-auto py-14">
                 <div className="w-full flex flex-col justify-center space-y-4 mb-6">
                   <Tooltip
                     content={`${name || 'Main'}`}
@@ -378,14 +378,18 @@ const CustomTool: React.FC<ConfigureProps> = ({ tool }) => {
                   )}
                 </div>
               </div>
-              <div className="h-full overflow-y-auto">
+              <div className="h-full overflow-y-auto pt-14">
                 <ChatContextProvider
                   initialScript={scriptPath}
                   enableThread={false}
                   initialSubTool={customTool.name}
                   initialScriptId={`${scriptId}`}
                 >
-                  <Chat disableInput={!customTool.chat} disableCommands={!customTool.chat} messagesHeight="h-[93%]" />
+                  <Chat
+                    disableInput={!customTool.chat}
+                    noChat={!customTool.chat}
+                    messagesHeight="h-[93%]"
+                  />
                 </ChatContextProvider>
               </div>
             </ModalBody>

--- a/components/edit/configure/params.tsx
+++ b/components/edit/configure/params.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Property } from '@gptscript-ai/gptscript';
 import { Input, Button } from '@nextui-org/react';
 import { GoPlus, GoTrash } from 'react-icons/go';
@@ -10,31 +9,10 @@ interface ExternalProps {
 }
 
 const Imports: React.FC<ExternalProps> = ({ params, setParams, className }) => {
-  const [error, setError] = useState<string | null>(null);
-  const [input, setInput] = useState<string>('');
-  const [inputDescription, setInputDescription] = useState<string>('');
-
   const handleDeleteParam = (param: string) => {
     const updatedParams = { ...params };
     delete updatedParams[param];
     setParams(updatedParams);
-  };
-
-  const handleAddParam = () => {
-    if (params && Object.keys(params)?.includes(input)) {
-      setError(`Parameter ${input} already exists`);
-      return;
-    }
-    if (!input) {
-      setError('Parameter cannot be empty');
-      return;
-    }
-    setParams({
-      ...(params || {}),
-      [input]: { type: 'string', description: inputDescription },
-    });
-    setInput('');
-    setInputDescription('');
   };
 
   const handleCreateDefaultParam = () => {
@@ -43,11 +21,6 @@ const Imports: React.FC<ExternalProps> = ({ params, setParams, className }) => {
     while (params && Object.keys(params)?.includes(defaultParamName)) {
       defaultParamName = `New Param ${counter}`;
       counter++;
-    }
-
-    if (params && Object.keys(params)?.includes(defaultParamName)) {
-      setError(`Parameter ${defaultParamName} already exists`);
-      return;
     }
 
     setParams({

--- a/components/edit/configure/params.tsx
+++ b/components/edit/configure/params.tsx
@@ -37,14 +37,27 @@ const Imports: React.FC<ExternalProps> = ({ params, setParams, className }) => {
     setInputDescription('');
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      handleAddParam();
+  const handleCreateDefaultParam = () => {
+    let defaultParamName = 'New Param';
+    let counter = 1;
+    while (params && Object.keys(params)?.includes(defaultParamName)) {
+      defaultParamName = `New Param ${counter}`;
+      counter++;
     }
+
+    if (params && Object.keys(params)?.includes(defaultParamName)) {
+      setError(`Parameter ${defaultParamName} already exists`);
+      return;
+    }
+
+    setParams({
+      ...(params || {}),
+      [defaultParamName]: { type: 'string', description: '' },
+    });
   };
 
   return (
-    <div className={className}>
+    <div className={`space-y-2 ${className}`}>
       {params &&
         Object.keys(params).map((param) => (
           <div key={param} className="flex space-x-2">
@@ -52,14 +65,14 @@ const Imports: React.FC<ExternalProps> = ({ params, setParams, className }) => {
               color="primary"
               size="sm"
               placeholder="Name..."
-              className="w-1/5"
+              className="w-3/4 2xl:w-1/4"
               variant="bordered"
               defaultValue={param}
               onBlur={(e) => {
                 const target = e.target as HTMLInputElement;
                 const updatedParams = { ...params };
-                updatedParams[target.value] = updatedParams[param];
                 delete updatedParams[param];
+                updatedParams[target.value] = params[param];
                 setParams(updatedParams);
               }}
             />
@@ -89,34 +102,12 @@ const Imports: React.FC<ExternalProps> = ({ params, setParams, className }) => {
           </div>
         ))}
       <div className="flex space-x-2 mt-2">
-        <Input
-          color="primary"
-          size="sm"
-          placeholder="Name..."
-          className="w-1/5"
-          variant="bordered"
-          value={input}
-          onChange={(e) => {
-            setError(null);
-            setInput(e.target.value);
-          }}
-          errorMessage={error}
-          isInvalid={!!error}
-          onKeyDown={handleKeyDown}
-        />
-        <Input
-          color="primary"
-          size="sm"
-          placeholder="Description..."
-          variant="bordered"
-          value={inputDescription}
-          onChange={(e) => setInputDescription(e.target.value)}
-          onKeyDown={handleKeyDown}
-        />
         <Button
-          variant="bordered"
+          variant="flat"
+          color="primary"
+          className="w-full"
           size="sm"
-          onClick={handleAddParam}
+          onClick={handleCreateDefaultParam}
           isIconOnly
           startContent={<GoPlus />}
         />


### PR DESCRIPTION
This fixes a few things relating to how setting parameters for sub tools work. It removed the "plus" button as well as the "enter" keybinding for new params. Instead, there is a new button to add params. This improves the UX since many users were getting confused why their params were not automatically persisting.

![Screenshot 2024-09-09 at 12 20 10 PM](https://github.com/user-attachments/assets/389bc0a3-b9f5-4a91-b737-97960eac8bcb)

There was another confusing issue where tools without chat would have the chat bar enabled. This has been addressed and looks like the following.

![Screenshot 2024-09-09 at 12 21 55 PM](https://github.com/user-attachments/assets/b361573f-1178-40fd-8e99-c658174449f4)

There is a third issue here where the running of this tool does not actually requests the user to input their parameters. This will be fixed in a follow-up to minimize the size of this PR. That change will take some work.

#413 