### PR TITLE
Fix: Make sure thread id is set before run

### DIFF
--- a/contexts/chat.tsx
+++ b/contexts/chat.tsx
@@ -236,7 +236,7 @@ const ChatContextProvider: React.FC<ChatContextProps> = ({
       !socket ||
       !connected ||
       !initialFetch ||
-      (enableThread && !threadInitialized.current)
+      (enableThread && (!thread || !threadInitialized.current))
     )
       return;
     socket.emit(


### PR DESCRIPTION
We need to make that before running thread, threadID is always set. Otherwise this will break thread knowledge functionality as it relies on query thread knowledge dataset based on threadID.

https://github.com/gptscript-ai/desktop/issues/425
https://github.com/gptscript-ai/desktop/issues/420