### PR TITLE
fix: fix app.mjs panic and create settings.json on startup

### DIFF
--- a/actions/appSettings.tsx
+++ b/actions/appSettings.tsx
@@ -28,7 +28,11 @@ export async function getAppSettings() {
   const location = process.env.GPTSCRIPT_SETTINGS_FILE;
   if (fs.existsSync(location)) {
     const AppSettings = fs.readFileSync(location, 'utf-8');
-    return JSON.parse(AppSettings) as AppSettings;
+    try {
+      return JSON.parse(AppSettings) as AppSettings;
+    } catch {
+      console.error('Malformed settings file, using default settings...');
+    }
   }
   return defaultAppSettings;
 }

--- a/actions/appSettings.tsx
+++ b/actions/appSettings.tsx
@@ -1,8 +1,6 @@
 'use server';
 
 import fs from 'fs';
-import os from 'os';
-import path from 'path';
 
 export type AppSettings = {
   confirmToolCalls: boolean;
@@ -19,7 +17,7 @@ const defaultAppSettings: AppSettings = {
   browser: {
     headless: false,
     useDefaultSession: false,
-  },
+  } as BrowserAppSettings,
 };
 
 export async function getAppSettings() {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -69,7 +69,7 @@ export default function SettingsPage() {
                   onValueChange={(isSelected) => {
                     setPendingSettings((prevState) => ({
                       ...prevState,
-                      headless: isSelected,
+                      browser: { ...prevState.browser, headless: isSelected },
                     }));
                   }}
                 >
@@ -89,7 +89,10 @@ export default function SettingsPage() {
                   onValueChange={(isSelected) => {
                     setPendingSettings((prevState) => ({
                       ...prevState,
-                      useDefaultSession: isSelected,
+                      browser: {
+                        ...prevState.browser,
+                        useDefaultSession: isSelected,
+                      },
                     }));
                   }}
                 >

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -13,15 +13,21 @@ async function startServer() {
   // Fix path so that tools can find binaries installed on the system.
   fixPath();
 
-  // Ensure the app's data directory exists
+  // Ensure the app's data and workspace directories exists
   ensureDirExists(config.dataDir);
-
-  // Set up the browser tool to run in headless mode.
   ensureDirExists(config.workspaceDir);
-  writeFileSync(
-    join(`${config.workspaceDir}`, 'settings.json'),
-    JSON.stringify({ headless: true })
-  );
+
+  // If the app settings file doesn't exist, create it with default settings.
+  if (!existsSync(config.appSettingsFile)) {
+    writeFileSync(
+      config.appSettingsFile, // created in config.mjs
+      JSON.stringify({
+        browser: {
+          headless: true,
+        },
+      })
+    );
+  }
 
   // Project config onto environment variables to configure GPTScript/sdk-server and the Next.js app.
   process.env.LOGS_DIR = config.logsDir;

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -145,7 +145,11 @@ const mount = async (
     },
   };
   if (existsSync(settingsLocation)) {
-    settings = JSON.parse(fs.readFileSync(settingsLocation, 'utf8'));
+    try {
+      settings = JSON.parse(fs.readFileSync(settingsLocation, 'utf8'));
+    } catch {
+      console.error('Malformed settings file, using default settings...');
+    }
   }
 
   let script;

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -4,7 +4,7 @@ import nextConfig from '../next.config.js';
 import { Server } from 'socket.io';
 import { GPTScript, RunEventType } from '@gptscript-ai/gptscript';
 import dotenv from 'dotenv';
-import fs from 'fs';
+import fs, { existsSync } from 'fs';
 import path from 'path';
 import os from 'os';
 
@@ -135,8 +135,18 @@ const mount = async (
     process.env.WORKSPACE_DIR ?? process.env.GPTSCRIPT_WORKSPACE_DIR;
   const THREADS_DIR =
     process.env.THREADS_DIR ?? path.join(WORKSPACE_DIR, 'threads');
+
+  // Get the settings file. If it doesn't exist, use default settings instead.
   const settingsLocation = process.env.GPTSCRIPT_SETTINGS_FILE;
-  const settings = JSON.parse(fs.readFileSync(settingsLocation, 'utf8'));
+  let settings = {
+    confirmToolCalls: false,
+    browser: {
+      headless: true,
+    },
+  };
+  if (existsSync(settingsLocation)) {
+    settings = JSON.parse(fs.readFileSync(settingsLocation, 'utf8'));
+  }
 
   let script;
   if (typeof location === 'string') {


### PR DESCRIPTION
There were some issues that were not caught in the last PR because a lot of the reviewers already had settings files. I didn't catch it while programming the settings page up for the same reason, to fix this this PR does 3 things.

1. The socket server now will use default settings if the settings file does not exist. This shouldn't happen, but just in case. This was an issue because of...
2. Create the settings.json file in the correct place, it was previously in the workspace dir which was incorrect. We now also only create it if it doesn't already exist.
3. Fixes an issue where the users could not set browser settings persistently. (noticed while fixing the root issue, but was not a cause of the root issue).

#480
https://acorn-io.slack.com/archives/C03FU91U4SX/p1725985732395979