### PR TITLE
Feat: Allow sys tools to be added by URL

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,6 @@
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_"}]
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_", "caughtErrorsIgnorePattern": "^_" }]
   }
 }

--- a/actions/gptscript.tsx
+++ b/actions/gptscript.tsx
@@ -17,8 +17,21 @@ export const parseContent = async (toolContent: string): Promise<Tool[]> => {
   ) as Tool[];
 };
 
-export const parseBlock = async (ref: string) => {
-  return await gpt().parse(ref);
+/**
+ * Verifies that a tool exists by parsing it.
+ * @param toolRef The tool reference to verify.
+ * @returns A boolean indicating whether the tool exists.
+ */
+export const verifyToolExists = async (toolRef: string) => {
+  // skip verification if the tool is a system tool
+  if (toolRef.startsWith('sys.')) return true;
+
+  try {
+    await gpt().parse(toolRef);
+    return true;
+  } catch (_) {
+    return false;
+  }
 };
 
 export const parse = async (file: string): Promise<Tool[]> => {

--- a/actions/scripts/fetch.tsx
+++ b/actions/scripts/fetch.tsx
@@ -20,11 +20,7 @@ export const path = async (file: string): Promise<string> => {
 export const fetchFullScript = async (file: string): Promise<Block[]> => {
   if (!external(file)) file = `${SCRIPTS_PATH()}/${file}.gpt`;
 
-  try {
-    return await gpt().parse(file);
-  } catch (e) {
-    throw e;
-  }
+  return await gpt().parse(file);
 };
 
 export const fetchScript = async (file: string): Promise<Tool> => {

--- a/components/chat/chatBar/commands.tsx
+++ b/components/chat/chatBar/commands.tsx
@@ -1,4 +1,4 @@
-import { getToolDisplayName, parseBlock } from '@/actions/gptscript';
+import { getToolDisplayName, verifyToolExists } from '@/actions/gptscript';
 import { ingest } from '@/actions/knowledge/knowledge';
 import { gatewayTool, getCookie } from '@/actions/knowledge/util';
 import { uploadFile } from '@/actions/upload';
@@ -234,9 +234,9 @@ export default forwardRef<ChatCommandsRef, CommandsProps>(
       if (tools.includes(tool)) throw new Error('Tool already added');
 
       setLoadingTool(tool);
-      const [foundTool] = await parseBlock(tool);
 
-      if (!foundTool) {
+      const toolExists = await verifyToolExists(tool);
+      if (!toolExists) {
         throw new Error(`Tool ${tool} does not exist`);
       }
 

--- a/components/edit/configure/imports.tsx
+++ b/components/edit/configure/imports.tsx
@@ -44,7 +44,7 @@ import {
 } from 'react-icons/si';
 import { VscAzure } from 'react-icons/vsc';
 
-import { getToolDisplayName, parse } from '@/actions/gptscript';
+import { getToolDisplayName, verifyToolExists } from '@/actions/gptscript';
 import {
   CatalogListBox,
   ToolCatalogRef,
@@ -116,7 +116,10 @@ const Imports: React.FC<ImportsProps> = ({
 
   const verifyAndAddToolUrl = useAsync(async (url: string) => {
     if (!url) throw new Error('Tool URL cannot be empty');
-    await parse(url); // throws if the url is invalid
+
+    const toolExists = await verifyToolExists(url);
+    if (!toolExists) throw new Error(`Tool ${url} does not exist`);
+
     setTools([...(tools || []), url]);
   });
 


### PR DESCRIPTION
This skips the verification step for tools that start with `sys.` to allow them to be added to chats and assistants

I opted not to include a hard-coded whitelist of system tools so that we could add/remove them without having to make UI updates. The downside is that adding an invalid sys tool could cause errors. Happy to update this if necessary