### PR TITLE
feat: add the ability to open files from the UI

### DIFF
--- a/components/chat/chatBar/upload/files.tsx
+++ b/components/chat/chatBar/upload/files.tsx
@@ -48,9 +48,7 @@ const Files: React.FC<FilesProps> = ({ files, setFiles }) => {
                   radius="full"
                   onPress={async () =>
                     // This submits a request to the electron main process to open the file
-                    (window as any).electronAPI.openFile(
-                      path.join(file.path, file.name)
-                    )
+                    window.electronAPI.openFile(path.join(file.path, file.name))
                   }
                 />
                 <Button

--- a/components/chat/chatBar/upload/files.tsx
+++ b/components/chat/chatBar/upload/files.tsx
@@ -47,8 +47,9 @@ const Files: React.FC<FilesProps> = ({ files, setFiles }) => {
                   color="primary"
                   radius="full"
                   onPress={async () =>
-                    window.alert(
-                      'Coming soon, we promise! This will open your file.'
+                    // This submits a request to the electron main process to open the file
+                    (window as any).electronAPI.openFile(
+                      path.join(file.path, file.name)
                     )
                   }
                 />

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import fixPath from 'fix-path';
 import os from 'os';
 import { config } from './config.mjs';
+import { ipcMain } from 'electron/main';
 
 app.on('window-all-closed', () => app.quit());
 app.on('ready', startServer);
@@ -71,6 +72,11 @@ function createWindow(url) {
       webSecurity: false,
       disableBlinkFeatures: 'Autofill',
     },
+  });
+
+  // This is necessary to allow the renderer process (NextJS) to open files in the default system application
+  ipcMain.on('open-file', (event, arg) => {
+    shell.openPath(arg);
   });
 
   // Check if the platform is macOS before calling setWindowButtonVisibility

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -11,4 +11,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   send: (channel, args) => {
     ipcRenderer.send(channel, args);
   },
+  openFile: (file) => ipcRenderer.send('open-file', file),
 });

--- a/types/window.d.ts
+++ b/types/window.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  interface Window {
+    electronAPI: {
+      openFile: (path: string) => void;
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
This uses Electron's IPC code to open system files through the UI. It is done through a listeners on in the `main.js` of electron and an emitter in the next js app. Once the emitted event is received with a file it is opened with the system default.

https://www.electronjs.org/docs/latest/tutorial/ipc for more info.

#322