### PR TITLE
fix: stop error when tool has no instructions

### DIFF
--- a/components/chat/useChatSocket.tsx
+++ b/components/chat/useChatSocket.tsx
@@ -141,7 +141,6 @@ const useChatSocket = () => {
       let content = isMainContent
         ? callFrame.output[callFrame.output.length - 1].content || ''
         : '';
-      if (!content) continue;
       setGenerating(true);
       if (
         content === 'Waiting for model response...' &&
@@ -157,13 +156,17 @@ const useChatSocket = () => {
       latestAgentMessageRef.current.message = content;
 
       if (isMainContent && callFrame.type === 'callFinish') {
+        if (!latestAgentMessageRef.current.message) {
+          latestAgentMessageRef.current.message =
+            "The message received from the assistant was empty, this happens if the tool doesn't have any instructions.";
+        }
         setMessages([
           ...messagesRef.current,
           { ...latestAgentMessageRef.current },
         ]);
         setLatestAgentMessage({} as Message);
         setGenerating(false);
-      } else {
+      } else if (latestAgentMessageRef.current.message) {
         setLatestAgentMessage({ ...latestAgentMessageRef.current });
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "v0.10.0-rc4",
       "hasInstallScript": true,
       "dependencies": {
-        "@gptscript-ai/gptscript": "^0.9.5-rc5",
+        "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#1cf71a66d0ca7cffe98343bf672f54a6a84d9ed0",
         "@monaco-editor/react": "^4.6.0",
         "@nextui-org/button": "2.0.32",
         "@nextui-org/code": "2.0.28",
@@ -519,9 +519,9 @@
       }
     },
     "node_modules/@gptscript-ai/gptscript": {
-      "version": "0.9.5-rc5",
-      "resolved": "https://registry.npmjs.org/@gptscript-ai/gptscript/-/gptscript-0.9.5-rc5.tgz",
-      "integrity": "sha512-hiLGvXNF65qIo4LUXfgr8+m7v4p+mnh3HICPRRKeyGBByVdlx+VIXgu7OA44oBJ8P4MZ+uW/+ROfPu/lHiso0g==",
+      "version": "v0.9.5-rc5",
+      "resolved": "git+ssh://git@github.com/gptscript-ai/node-gptscript.git#1cf71a66d0ca7cffe98343bf672f54a6a84d9ed0",
+      "integrity": "sha512-O1M6LZ+f/3g5s0w1yywXmKVBg+o3r1NM9+nmfo4FbAe3in/GfYc4v/hXZxu/gPyhVaFNFwnjUQIsbqMW1iNDzA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5330,9 +5330,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.15.tgz",
-      "integrity": "sha512-jYPWSeOA8EFoZnucrKCNihqBjoEGQSU4HKgHYQgKNEQ0pQF9a/DYuo/+fAxY76k4qe75LUlLWpAM1QWcBMTOKw==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "main": "electron/main.mjs",
   "dependencies": {
-    "@gptscript-ai/gptscript": "^0.9.5-rc5",
+    "@gptscript-ai/gptscript": "github:gptscript-ai/node-gptscript#1cf71a66d0ca7cffe98343bf672f54a6a84d9ed0",
     "@monaco-editor/react": "^4.6.0",
     "@nextui-org/button": "2.0.32",
     "@nextui-org/code": "2.0.28",


### PR DESCRIPTION
Previously, if a tool had no instructions, then the SDK would report an error because there would have been no output. That has been changed in the SDK.

Now, in these changes, if a blank message is received when running a tool, a special "no response received" message will be displayed to the user.