### PR TITLE
fix: address issue where you would have to hit interrupt twice

### DIFF
--- a/components/chat/useChatSocket.tsx
+++ b/components/chat/useChatSocket.tsx
@@ -411,6 +411,7 @@ const useChatSocket = () => {
     socket.on('interrupted', () => {
       setGenerating(false);
       setWaitingForUserResponse(false);
+      workQueue.current = [];
       setMessages((prevMessages) => {
         return [...prevMessages, latestAgentMessageRef.current];
       });


### PR DESCRIPTION
Prior the work queue wouldn't be cleared which would cause a race condition between the interrupt and the processing message in the queue.