### PR TITLE
feat: add download option for stack traces

### DIFF
--- a/components/chat/messages/calls.tsx
+++ b/components/chat/messages/calls.tsx
@@ -13,6 +13,7 @@ import {
   Button,
   Tooltip,
 } from '@nextui-org/react';
+import SaveFile from '@/components/saveFile';
 
 const Calls = ({ calls }: { calls: Record<string, CallFrame> }) => {
   const [showModal, setShowModal] = useState(false);
@@ -41,7 +42,10 @@ const Calls = ({ calls }: { calls: Record<string, CallFrame> }) => {
         <ModalContent>
           <ModalHeader className="flex justify-between">
             <div>
-              <h1 className="text-2xl my-4">Stack Trace</h1>
+              <div className="my-2">
+                <h1 className="text-2xl  inline mr-2">Stack Trace</h1>
+                <SaveFile content={calls} />
+              </div>
               <h2 className="text-base text-zinc-500">
                 Below you can see what this call is doing or has done.
               </h2>

--- a/components/chat/messages/calls/stackTrace.tsx
+++ b/components/chat/messages/calls/stackTrace.tsx
@@ -3,7 +3,6 @@ import { Button, Tooltip } from '@nextui-org/react';
 import type { CallFrame } from '@gptscript-ai/gptscript';
 import { GoArrowDown, GoArrowUp } from 'react-icons/go';
 import { AiOutlineLoading3Quarters } from 'react-icons/ai';
-import SaveFile from '@/components/saveFile';
 
 const StackTrace = ({ calls }: { calls: Record<string, CallFrame> | null }) => {
   if (!calls) return null;
@@ -132,7 +131,6 @@ const StackTrace = ({ calls }: { calls: Record<string, CallFrame> | null }) => {
           {allOpen ? <GoArrowUp /> : <GoArrowDown />}
         </Button>
       </Tooltip>
-      <SaveFile content={calls} className="absolute bottom-9 right-8" />
       {calls ? <RenderLogs /> : <EmptyLogs />}
     </div>
   );

--- a/components/chat/messages/calls/stackTrace.tsx
+++ b/components/chat/messages/calls/stackTrace.tsx
@@ -3,6 +3,7 @@ import { Button, Tooltip } from '@nextui-org/react';
 import type { CallFrame } from '@gptscript-ai/gptscript';
 import { GoArrowDown, GoArrowUp } from 'react-icons/go';
 import { AiOutlineLoading3Quarters } from 'react-icons/ai';
+import SaveFile from '@/components/saveFile';
 
 const StackTrace = ({ calls }: { calls: Record<string, CallFrame> | null }) => {
   if (!calls) return null;
@@ -131,6 +132,7 @@ const StackTrace = ({ calls }: { calls: Record<string, CallFrame> | null }) => {
           {allOpen ? <GoArrowUp /> : <GoArrowDown />}
         </Button>
       </Tooltip>
+      <SaveFile content={calls} className="absolute bottom-9 right-8" />
       {calls ? <RenderLogs /> : <EmptyLogs />}
     </div>
   );

--- a/components/saveFile.tsx
+++ b/components/saveFile.tsx
@@ -1,0 +1,29 @@
+import { Button, Tooltip } from '@nextui-org/react';
+import React from 'react';
+import { GoDownload } from 'react-icons/go';
+
+interface Props {
+  content: any; // any javascript object
+  className?: string;
+}
+
+const SaveFile: React.FC<Props> = ({ content, className }) => {
+  const handleSave = () => {
+    window.electronAPI.saveFile(JSON.stringify(content, null, 2));
+  };
+
+  return (
+    <Tooltip content={'Download Stack Trace'} closeDelay={0}>
+      <Button
+        onPress={handleSave}
+        className={className}
+        isIconOnly
+        radius="full"
+        color="primary"
+        startContent={<GoDownload />}
+      />
+    </Tooltip>
+  );
+};
+
+export default SaveFile;

--- a/components/saveFile.tsx
+++ b/components/saveFile.tsx
@@ -15,11 +15,11 @@ const SaveFile: React.FC<Props> = ({ content, className }) => {
   return (
     <Tooltip content={'Download Stack Trace'} closeDelay={0}>
       <Button
+        size="sm"
         onPress={handleSave}
         className={className}
         isIconOnly
         radius="full"
-        color="primary"
         startContent={<GoDownload />}
       />
     </Tooltip>

--- a/components/saveFile.tsx
+++ b/components/saveFile.tsx
@@ -2,12 +2,12 @@ import { Button, Tooltip } from '@nextui-org/react';
 import React from 'react';
 import { GoDownload } from 'react-icons/go';
 
-interface Props {
+interface SaveFileProps {
   content: any; // any javascript object
   className?: string;
 }
 
-const SaveFile: React.FC<Props> = ({ content, className }) => {
+const SaveFile: React.FC<SaveFileProps> = ({ content, className }) => {
   const handleSave = () => {
     window.electronAPI.saveFile(JSON.stringify(content, null, 2));
   };

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -12,4 +12,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.send(channel, args);
   },
   openFile: (file) => ipcRenderer.send('open-file', file),
+  saveFile: (content) => ipcRenderer.send('save-file', content),
 });

--- a/types/window.d.ts
+++ b/types/window.d.ts
@@ -2,6 +2,7 @@ declare global {
   interface Window {
     electronAPI: {
       openFile: (path: string) => void;
+      saveFile: (content: string) => void;
     };
   }
 }


### PR DESCRIPTION
This PR adds a new feature allowing users to download stack traces of messages. It uses electron API's to do this and uses native API's to interact with the default file system of the user's OS.

<details>

<summary> Demonstration </summary>

https://github.com/user-attachments/assets/136f6daa-e33f-4ed6-b971-24530f998ead

</details>

#471 
