### PR TITLE
Fix: log ingestion error to stdout

### DIFF
--- a/actions/knowledge/knowledge.ts
+++ b/actions/knowledge/knowledge.ts
@@ -96,6 +96,7 @@ export async function ensureFilesIngested(
       token
     );
   } catch (error) {
+    console.error(error);
     return `Error running knowledge ingestion: ${error}`;
   }
 


### PR DESCRIPTION
Log ingestion error to app log. Today we already show it in UI with truncated text but we should show the full error in acorn.log.